### PR TITLE
Travis coverals setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+python:
+  - '3.6'
+
+install:
+  - pip install pytest
+  - pip install --editable .
+
+script:
+  - py.test -v tests/*
+
+notification:
+  - email: false

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+[![BuildStatus](https://travis-ci.org/Clinical-Genomics/BALSAMIC.svg?branch=master)](https://travis-ci.org/Clinical-Genomics/BALSAMIC)
+
 ========
 BALSAMIC
 ========

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-[![BuildStatus](https://travis-ci.org/Clinical-Genomics/BALSAMIC.svg?branch=master)](https://travis-ci.org/Clinical-Genomics/BALSAMIC)
+.. image:: https://travis-ci.org/Clinical-Genomics/BALSAMIC.svg?branch=master 
+    :target: https://travis-ci.org/Clinical-Genomics/BALSAMIC
 
 ========
 BALSAMIC

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/Clinical-Genomics/BALSAMIC.svg?branch=master 
     :target: https://travis-ci.org/Clinical-Genomics/BALSAMIC
 
+.. image:: https://coveralls.io/repos/github/Clinical-Genomics/BALSAMIC/badge.svg?branch=master 
+    :target: https://coveralls.io/github/Clinical-Genomics/BALSAMIC 
+
 ========
 BALSAMIC
 ========

--- a/tests/install/test_install_conda.py
+++ b/tests/install/test_install_conda.py
@@ -1,4 +1,4 @@
-from BALSAMIC.install import conda_env_check, conda_default_prefix, get_prefix
+from BALSAMIC.commands.install import conda_default_prefix, conda_env_check, get_prefix
 from unittest import TestCase, mock
 import subprocess
 import yaml


### PR DESCRIPTION
This PR adds .travis.yml, and build+coveralls status logo.

How to test:
1. Change branch on the browser travis_coverals_setup and the following should be visible:
![image](https://user-images.githubusercontent.com/1086877/57695513-bfdd7880-764e-11e9-8f12-a06f889795e6.png)
2. Also, the target and image in the README.rst should be there.

Expected outcome:
1. README.rst should have two URLs+image and it should show the status. 

@ingkebil how does a PR should look like for documentation? Thanks in advance for looking into this.