### PR TITLE
Added new testcases for config-sample and UMI flag

### DIFF
--- a/BALSAMIC/commands/config/__init__.py
+++ b/BALSAMIC/commands/config/__init__.py
@@ -1,3 +1,4 @@
 from .base import config
 from .sample import get_config
-from .sample import write_json
+from .sample import write_json, merge_json, set_panel_bed, get_output_config, \
+					get_sample_config, get_analysis_type, check_exist

--- a/BALSAMIC/commands/config/__init__.py
+++ b/BALSAMIC/commands/config/__init__.py
@@ -1,4 +1,4 @@
 from .base import config
 from .sample import get_config
 from .sample import write_json, merge_json, set_panel_bed, get_output_config, \
-					get_sample_config, get_analysis_type, check_exist
+     get_sample_config, get_analysis_type, check_exist

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -56,9 +56,10 @@ def get_config(config_name):
 
     try:
         p = Path(__file__).parents[2]
+        Path(p, 'config', config_name + ".json").exists()
         config_file = str(Path(p, 'config', config_name + ".json"))
     except OSError:
-        print("Couldn't locate config file" + config_name + ".json")
+        raise
 
     return config_file
 

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -35,7 +35,6 @@ def merge_json(*args):
                 with open(json_file) as fn:
                     json_out = {**json_out, **json.load(fn)}
         except OSError as error:
-            print("File not found", json_file)
             raise error
 
     return json_out
@@ -48,7 +47,6 @@ def write_json(json_out, output_config):
             json.dump(json_out, fn)
     except OSError as error:
         raise error
-        print("Write failed")
 
 
 def get_config(config_name):
@@ -77,7 +75,6 @@ def set_panel_bed(json_out, panel_bed):
         json_out["bed"]["chrom"] = get_chrom(panel_bed)
 
     except OSError as error:
-        print("Couldn't locate bed file" + panel_bed)
         raise error
 
     return json_out
@@ -91,9 +88,8 @@ def check_exist(path):
     try:
         f = open(path, "r")
         f.close()
-    except (IOError, FileNotFoundError) as e:
-        print("File not found or unreadable.", path)
-        raise e
+    except (IOError, FileNotFoundError) as error:
+        raise error
 
     return True
 

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -97,12 +97,13 @@ def check_exist(path):
 
     return True
 
-def get_analysis_type(normal):
+def get_analysis_type(normal, umi):
     """ return analysis type """
-    if normal:
-        return "paired"
+    if umi:
+        return "paired_umi" if normal else "single_umi"
     else:
-        return "single"
+        return "paired" if normal else "single"
+
 
 def get_output_config(config):
     """ return output config json file"""
@@ -166,14 +167,9 @@ def link_fastq(src_path, dst_path, sample_name, read_prefix, check_fastq,
 @click.command("sample",
                short_help="Create a sample config file from input sample data")
 @click.option(
-    "-a",
-    "--analysis-type",
-    required=False,
-    default="single",
-    show_default=True,
-    type=click.Choice(["paired", "single", "paired_umi", "single_umi"]),
-    help=
-    "Analysis config file for paired (tumor vs normal) or single (tumor-only) mode.",
+    '--umi', 
+    is_flag=True,
+    help="UMI processing steps for samples with umi tags"
 )
 @click.option(
     "-i",
@@ -265,7 +261,7 @@ def link_fastq(src_path, dst_path, sample_name, read_prefix, check_fastq,
 @click.pass_context
 def sample(
         context,
-        analysis_type,
+        umi,
         install_config,
         sample_config,
         reference_config,
@@ -287,7 +283,7 @@ it is. So this is just a placeholder for future.
 
     """
 
-    analysis_type = get_analysis_type(normal)
+    analysis_type = get_analysis_type(normal, umi)
 
     output_config = get_output_config(output_config)
 

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -54,12 +54,8 @@ def get_config(config_name):
     Return a string path for config file.
     """
 
-    try:
-        p = Path(__file__).parents[2]
-        Path(p, 'config', config_name + ".json").exists()
-        config_file = str(Path(p, 'config', config_name + ".json"))
-    except OSError:
-        raise
+    p = Path(__file__).parents[2]
+    config_file = str(Path(p, 'config', config_name + ".json"))
 
     return config_file
 

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -105,7 +105,7 @@ def get_analysis_type(normal, umi):
         return "paired" if normal else "single"
 
 
-def get_output_config(config):
+def get_output_config(config, sample_id):
     """ return output config json file"""
     if not config:
         return sample_id + "_" + datetime.now().strftime(
@@ -285,7 +285,7 @@ it is. So this is just a placeholder for future.
 
     analysis_type = get_analysis_type(normal, umi)
 
-    output_config = get_output_config(output_config)
+    output_config = get_output_config(output_config, sample_id)
 
     analysis_config = get_config("analysis_" + analysis_type)
 

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -59,9 +59,9 @@ def get_config(config_name):
     try:
         p = Path(__file__).parents[2]
         config_file = str(Path(p, 'config', config_name + ".json"))
-    except OSError:        
+    except OSError:
         print("Couldn't locate config file" + config_name + ".json")
-    
+
     return config_file
 
 
@@ -97,6 +97,7 @@ def check_exist(path):
 
     return True
 
+
 def get_analysis_type(normal, umi):
     """ return analysis type """
     if umi:
@@ -108,10 +109,10 @@ def get_analysis_type(normal, umi):
 def get_output_config(config, sample_id):
     """ return output config json file"""
     if not config:
-        return sample_id + "_" + datetime.now().strftime(
-            "%Y%m%d") + ".json"
+        return sample_id + "_" + datetime.now().strftime("%Y%m%d") + ".json"
     else:
         return config
+
 
 def get_sample_config(sample_config, sample_id, analysis_dir, analysis_type):
     """
@@ -166,11 +167,9 @@ def link_fastq(src_path, dst_path, sample_name, read_prefix, check_fastq,
 
 @click.command("sample",
                short_help="Create a sample config file from input sample data")
-@click.option(
-    '--umi', 
-    is_flag=True,
-    help="UMI processing steps for samples with umi tags"
-)
+@click.option('--umi',
+              is_flag=True,
+              help="UMI processing steps for samples with umi tags")
 @click.option(
     "-i",
     "--install-config",
@@ -302,9 +301,10 @@ it is. So this is just a placeholder for future.
         sample_config_path = get_config("sample")
 
     click.echo("Reading sample config file %s" % sample_config_path)
-    
-    sample_config = get_sample_config(sample_config_path, sample_id, analysis_dir, analysis_type)
-    
+
+    sample_config = get_sample_config(sample_config_path, sample_id,
+                                      analysis_dir, analysis_type)
+
     output_dir = os.path.join(os.path.abspath(analysis_dir), sample_id)
 
     if create_dir:

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -128,3 +128,33 @@ def test_check_exist_error():
 
         #THEN It will raise the error 
         assert "FileIsNotFound" in str(error.value)
+
+def test_get_analysis_type():
+    #GIVEN umi flag(boolean value) and normal fq file 
+    umi_true = True 
+    normal_valid = 'normal.fastq'
+    umi_false = False 
+    normal_invalid = ''
+    #WHEN passing values 
+    #THEN it will return possible analysis type
+    assert 'paired_umi' == get_analysis_type(normal_valid, umi_true)
+    assert 'single_umi' == get_analysis_type(normal_invalid, umi_true)
+    assert 'paired' == get_analysis_type(normal_valid, umi_false)
+    assert 'single' == get_analysis_type(normal_invalid, umi_false)
+
+def test_get_output_config():
+    #GIVEN a config arg and sample id 
+    sample_id = 'test_sample'
+    config_json = 'config.json'
+    _config_json = ''
+
+    #WHEN passing values 
+    config = get_output_config(config_json, sample_id)
+    _config = get_output_config(_config_json, sample_id)
+    #THEN it will return config json file
+    assert config != ''
+    assert _config != ''
+    assert config.split('.')[-1] == 'json'
+    assert _config.split('.')[-1] == 'json'
+
+

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -9,7 +9,6 @@ from BALSAMIC.commands.config import get_config, write_json, merge_json, \
 from BALSAMIC.tools import iterdict
 
 
-
 def test_get_config(config_files):
     # GIVEN the config files name
     files = [
@@ -41,19 +40,20 @@ def test_write_json(tmp_path, config_files):
 
     assert len(list(tmp.iterdir())) == 1
 
+
 def test_write_json_error(tmp_path, config_files):
     with pytest.raises(OSError) as error:
-        #GIVEN a invalid dict 
-        ref_json = {"path": "/tmp","reference": ""}
+        #GIVEN a invalid dict
+        ref_json = {"path": "/tmp", "reference": ""}
         tmp = tmp_path / "tmp"
         tmp.mkdir()
         output_json = tmp / "/"
 
-        #WHEN passing a invalid dict 
+        #WHEN passing a invalid dict
         value = write_json(ref_json, output_json)
 
     assert "Is a directory" in str(error.value)
-    
+
 
 def test_merge_json(config_files):
     #GIVEN a dict and json file
@@ -112,10 +112,10 @@ def test_set_panel_bed_error(config_files):
 
 
 def test_check_exist(config_files):
-    #GVIEN a file path 
+    #GVIEN a file path
     reference_json = config_files['reference']
 
-    #WHEN passing ref file path 
+    #WHEN passing ref file path
     check = check_exist(reference_json)
 
     #THEN It will return the boolean value if the file exists in path
@@ -130,17 +130,17 @@ def test_check_exist_error():
         #WHEN passing a invalid file path
         check = check_exist(invalid_file_path)
 
-        #THEN It will raise the error 
+        #THEN It will raise the error
         assert "FileIsNotFound" in str(error.value)
 
 
 def test_get_analysis_type():
-    #GIVEN umi flag(boolean value) and normal fq file 
-    umi_true = True 
+    #GIVEN umi flag(boolean value) and normal fq file
+    umi_true = True
     normal_valid = 'normal.fastq'
-    umi_false = False 
+    umi_false = False
     normal_invalid = ''
-    #WHEN passing values 
+    #WHEN passing values
     #THEN it will return possible analysis type
     assert 'paired_umi' == get_analysis_type(normal_valid, umi_true)
     assert 'single_umi' == get_analysis_type(normal_invalid, umi_true)
@@ -149,12 +149,12 @@ def test_get_analysis_type():
 
 
 def test_get_output_config():
-    #GIVEN a config arg and sample id 
+    #GIVEN a config arg and sample id
     sample_id = 'test_sample'
     config_json = 'config.json'
     _config_json = ''
 
-    #WHEN passing values 
+    #WHEN passing values
     config = get_output_config(config_json, sample_id)
     _config = get_output_config(_config_json, sample_id)
 
@@ -173,12 +173,11 @@ def test_get_sample_config(config_files):
     analysis_type = 'paired'
 
     #WHEN passing args into the function
-    sample_config = get_sample_config(sample_config, sample_id, analysis_dir, analysis_type)
+    sample_config = get_sample_config(sample_config, sample_id, analysis_dir,
+                                      analysis_type)
     date = datetime.now().strftime("%Y-%m-%d %H:%M")
 
     #THEN it will return the updated python dict with given values
     assert isinstance(sample_config, dict) == True
     assert sample_id in sample_config['analysis'].values()
     assert date in sample_config['analysis'].values()
-
-

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -1,11 +1,13 @@
 import os
 import json
 import pytest
+from datetime import datetime
 
 from BALSAMIC.commands.config import get_config, write_json, merge_json, \
                         set_panel_bed, get_output_config, get_sample_config,  \
                         get_analysis_type, check_exist
 from BALSAMIC.tools import iterdict
+
 
 
 def test_get_config(config_files):
@@ -108,6 +110,7 @@ def test_set_panel_bed_error(config_files):
         #THEN It will add two more items into the dict
         assert "FileIsNotFound" in str(error.value)
 
+
 def test_check_exist(config_files):
     #GVIEN a file path 
     reference_json = config_files['reference']
@@ -117,6 +120,7 @@ def test_check_exist(config_files):
 
     #THEN It will return the boolean value if the file exists in path
     assert check == True
+
 
 def test_check_exist_error():
     with pytest.raises(FileNotFoundError) as error:
@@ -128,6 +132,7 @@ def test_check_exist_error():
 
         #THEN It will raise the error 
         assert "FileIsNotFound" in str(error.value)
+
 
 def test_get_analysis_type():
     #GIVEN umi flag(boolean value) and normal fq file 
@@ -142,6 +147,7 @@ def test_get_analysis_type():
     assert 'paired' == get_analysis_type(normal_valid, umi_false)
     assert 'single' == get_analysis_type(normal_invalid, umi_false)
 
+
 def test_get_output_config():
     #GIVEN a config arg and sample id 
     sample_id = 'test_sample'
@@ -151,10 +157,28 @@ def test_get_output_config():
     #WHEN passing values 
     config = get_output_config(config_json, sample_id)
     _config = get_output_config(_config_json, sample_id)
+
     #THEN it will return config json file
     assert config != ''
     assert _config != ''
     assert config.split('.')[-1] == 'json'
     assert _config.split('.')[-1] == 'json'
+
+
+def test_get_sample_config(config_files):
+    #GIVEN a sample config json with sample id, analysis dir, analysis type
+    sample_id = 'sample1'
+    sample_config = config_files['sample']
+    analysis_dir = './'
+    analysis_type = 'paired'
+
+    #WHEN passing args into the function
+    sample_config = get_sample_config(sample_config, sample_id, analysis_dir, analysis_type)
+    date = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    #THEN it will return the updated python dict with given values
+    assert isinstance(sample_config, dict) == True
+    assert sample_id in sample_config['analysis'].values()
+    assert date in sample_config['analysis'].values()
 
 

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -1,7 +1,6 @@
-import os
 import json
-import pytest
 from datetime import datetime
+import pytest
 
 from BALSAMIC.commands.config import get_config, write_json, merge_json, \
                         set_panel_bed, get_output_config, get_sample_config,  \
@@ -50,9 +49,8 @@ def test_write_json_error(tmp_path, config_files):
         output_json = tmp / "/"
 
         #WHEN passing a invalid dict
-        value = write_json(ref_json, output_json)
-
-    assert "Is a directory" in str(error.value)
+        #THEN It will raise the error
+        assert write_json(ref_json, output_json)
 
 
 def test_merge_json(config_files):
@@ -65,7 +63,7 @@ def test_merge_json(config_files):
     merge_dict = merge_json(ref_dict, json_file)
 
     # THEN It will merge both the data and return dict
-    assert isinstance(merge_dict, dict) == True
+    assert isinstance(merge_dict, dict)
     assert "samples" in merge_dict
     assert "references" in merge_dict
 
@@ -74,14 +72,11 @@ def test_merge_json_error(config_files):
     with pytest.raises(OSError) as error:
         #GIVEN a dict and invalid json file path
         ref_dict = json.load(open(config_files['reference'], 'r'))
-
         json_file = 'reference.json'
 
         #WHEN passing python dict and invalid json path
-        merge_dict = merge_json(ref_dict, json_file)
-
         #THEN it should throw OSError as FileNotFoundError
-        assert 'FileNotFoundError' in error.value
+        assert merge_json(ref_dict, json_file)
 
 
 def test_set_panel_bed(config_files):
@@ -101,14 +96,11 @@ def test_set_panel_bed_error(config_files):
     with pytest.raises(OSError) as error:
         #GIVEN test reference json file and invalid panel bed file path
         ref_json = json.load(open(config_files['reference'], 'r'))
-
         panel_bed = "panel/panel.bed"
 
         #WHEN passing args to that function
-        json_out = set_panel_bed(ref_json, panel_bed)
-
         #THEN It will add two more items into the dict
-        assert "FileIsNotFound" in str(error.value)
+        assert set_panel_bed(ref_json, panel_bed)
 
 
 def test_check_exist(config_files):
@@ -116,10 +108,8 @@ def test_check_exist(config_files):
     reference_json = config_files['reference']
 
     #WHEN passing ref file path
-    check = check_exist(reference_json)
-
-    #THEN It will return the boolean value if the file exists in path
-    assert check == True
+    #THEN It will return true if the file exists in path
+    assert check_exist(reference_json)
 
 
 def test_check_exist_error():
@@ -128,10 +118,8 @@ def test_check_exist_error():
         invalid_file_path = "test.txt"
 
         #WHEN passing a invalid file path
-        check = check_exist(invalid_file_path)
-
         #THEN It will raise the error
-        assert "FileIsNotFound" in str(error.value)
+        assert check_exist(invalid_file_path)
 
 
 def test_get_analysis_type():
@@ -140,12 +128,13 @@ def test_get_analysis_type():
     normal_valid = 'normal.fastq'
     umi_false = False
     normal_invalid = ''
+
     #WHEN passing values
     #THEN it will return possible analysis type
-    assert 'paired_umi' == get_analysis_type(normal_valid, umi_true)
-    assert 'single_umi' == get_analysis_type(normal_invalid, umi_true)
-    assert 'paired' == get_analysis_type(normal_valid, umi_false)
-    assert 'single' == get_analysis_type(normal_invalid, umi_false)
+    assert get_analysis_type(normal_valid, umi_true) == 'paired_umi'
+    assert get_analysis_type(normal_invalid, umi_true) == 'single_umi'
+    assert get_analysis_type(normal_valid, umi_false) == 'paired'
+    assert get_analysis_type(normal_invalid, umi_false) == 'single'
 
 
 def test_get_output_config():

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -41,7 +41,7 @@ def test_write_json(tmp_path, config_files):
 
 
 def test_write_json_error(tmp_path, config_files):
-    with pytest.raises(OSError) as error:
+    with pytest.raises(Exception, match=r"Is a directory") as error:
         #GIVEN a invalid dict
         ref_json = {"path": "/tmp", "reference": ""}
         tmp = tmp_path / "tmp"
@@ -69,7 +69,7 @@ def test_merge_json(config_files):
 
 
 def test_merge_json_error(config_files):
-    with pytest.raises(OSError) as error:
+    with pytest.raises(Exception, match=r"No such file or directory") as error:
         #GIVEN a dict and invalid json file path
         ref_dict = json.load(open(config_files['reference'], 'r'))
         json_file = 'reference.json'
@@ -93,7 +93,7 @@ def test_set_panel_bed(config_files):
 
 
 def test_set_panel_bed_error(config_files):
-    with pytest.raises(OSError) as error:
+    with pytest.raises(Exception, match=r"No such file or directory") as error:
         #GIVEN test reference json file and invalid panel bed file path
         ref_json = json.load(open(config_files['reference'], 'r'))
         panel_bed = "panel/panel.bed"
@@ -113,7 +113,7 @@ def test_check_exist(config_files):
 
 
 def test_check_exist_error():
-    with pytest.raises(FileNotFoundError) as error:
+    with pytest.raises(Exception, match=r"No such file or directory") as error:
         #GIVEN a invalid file path
         invalid_file_path = "test.txt"
 
@@ -167,6 +167,6 @@ def test_get_sample_config(config_files):
     date = datetime.now().strftime("%Y-%m-%d %H:%M")
 
     #THEN it will return the updated python dict with given values
-    assert isinstance(sample_config, dict) == True
+    assert isinstance(sample_config, dict)
     assert sample_id in sample_config['analysis'].values()
     assert date in sample_config['analysis'].values()

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -35,15 +35,6 @@ def test_sample_missing_opt(invoke_cli):
     assert 'Error: Missing option' in result.output
     assert result.exit_code == 2
 
-
-def test_sample_invalid(invoke_cli):
-    """ Invalid option for analysis type """
-    result = invoke_cli(['config', 'sample', '-a', 'foo'])
-
-    assert result.exit_code == 2
-    assert 'Error: Invalid' in result.output
-
-
 def test_install(invoke_cli):
 
     result = invoke_cli(['install', '--help'])

--- a/tests/commands/test_cli.py
+++ b/tests/commands/test_cli.py
@@ -35,6 +35,7 @@ def test_sample_missing_opt(invoke_cli):
     assert 'Error: Missing option' in result.output
     assert result.exit_code == 2
 
+
 def test_install(invoke_cli):
 
     result = invoke_cli(['install', '--help'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,5 +29,6 @@ def config_files():
         "analysis_paired": "BALSAMIC/config/analysis_paired.json",
         "analysis_paired_umi": "BALSAMIC/config/analysis_paired_umi.json",
         "analysis_single": "BALSAMIC/config/analysis_single.json",
-        "analysis_single_umi": "BALSAMIC/config/analysis_single_umi.json"
+        "analysis_single_umi": "BALSAMIC/config/analysis_single_umi.json",
+        "panel_bed_file": "tests/test_data/references/GRCh37/panel/panel.bed"
     }


### PR DESCRIPTION
  1. Functional testing added for config-sample command.
  2. To get analysis type, `--umi` flag was added and `--analysis_type` was removed from config-sample command.
  3. Based on this umi flag and normal sample, balsamic will calculate the analysis type.

**How to Test:**
 1. Change the directory to BALSAMIC - `cd BALSAMIC`
 2. Pull the code from `test_sample` branch
 3. Run this `pytest tests/` - for functional testing

For `--umi` implementation:
 1. Run `balsamic config sample --help`, to test implementation of `--umi` option
 2. change the directory - `tests/test_data`
 3. `--umi` option is a flag. Here, we are testing for `paired` analysis type. so, run balsamic with normal sample and without umi flag,
`balsamic config sample     --tumor fastq/S1_R_1.fastq.gz     --normal fastq/S2_R_1.fastq.gz     --panel-bed references/GRCh37/panel/panel.bed     --sample-id id1     --analysis-dir ./    --output-config id1_analysis.json     --reference-config references/reference.json`

**Expected outcome:**
 1. Testing should be run without error. 25 test cases should be passed.
 2. BALSAMIC should be configured without error while running the command for `paired` analysis.
 3. DAG file should be created.
 4. `-a / --analysis_type` option should be removed from `config sample` command

