### PR TITLE
Update result_dir path as an intra-rule variable

### DIFF
--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format

--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
-cutadapt_dir = get_result_dir(config) + "/cutadapt/"
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 rule bwa_mem:

--- a/BALSAMIC/snakemake_rules/align/samtools.rule
+++ b/BALSAMIC/snakemake_rules/align/samtools.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 rule samtools_sort_index:

--- a/BALSAMIC/snakemake_rules/align/samtools.rule
+++ b/BALSAMIC/snakemake_rules/align/samtools.rule
@@ -3,9 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
 
 rule samtools_sort_index:
   input:

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 rule vep:

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -3,12 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-#vcf_sv_dir = get_result_dir(config) + "/vcf/SV/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 rule vep:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -3,11 +3,9 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
-result_dir = get_result_dir(config) + "/"
 
 rule RealignerTargetCreator:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/quality_control/collectqc_paired.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/collectqc_paired.rule
@@ -3,9 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-result_dir = get_result_dir(config) + "/" 
 picarddup = get_picard_mrkdup(config)
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format

--- a/BALSAMIC/snakemake_rules/quality_control/collectqc_paired.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/collectqc_paired.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/quality_control/collectqc_single.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/collectqc_single.rule
@@ -3,9 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-result_dir = get_result_dir(config) + "/"
 picarddup = get_picard_mrkdup(config)
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format

--- a/BALSAMIC/snakemake_rules/quality_control/collectqc_single.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/collectqc_single.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/quality_control/contest.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/contest.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 

--- a/BALSAMIC/snakemake_rules/quality_control/contest.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/contest.rule
@@ -3,11 +3,9 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
 
-result_dir = get_result_dir(config) + "/"
 
 rule GATK_contest:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/cutadapt.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/cutadapt.rule
@@ -4,9 +4,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-cutadapt_dir = get_result_dir(config) + "/cutadapt/"
 
 # remove adapter from paired end reads
 rule cutadapt:

--- a/BALSAMIC/snakemake_rules/quality_control/cutadapt.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/cutadapt.rule
@@ -4,7 +4,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 # remove adapter from paired end reads

--- a/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format

--- a/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-fastqc_dir = get_result_dir(config) + "/fastqc/"
-cutadapt_dir = get_result_dir(config) + "/cutadapt/"
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 rule fastqc:

--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-resultdir = get_result_dir(config) + "/" 
 picarddup = get_picard_mrkdup(config)
 
 def picard_flag(picarddup):

--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -3,9 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
 
 rule sambamba_panel_depth:

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/umi/bwa_mem_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/bwa_mem_umi.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 rule bwa_mem_umi_mrkadp:

--- a/BALSAMIC/snakemake_rules/umi/bwa_mem_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/bwa_mem_umi.rule
@@ -3,9 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
 
 rule bwa_mem_umi_mrkadp:
   input:

--- a/BALSAMIC/snakemake_rules/umi/fgbio.rule
+++ b/BALSAMIC/snakemake_rules/umi/fgbio.rule
@@ -2,7 +2,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 rule fgbio_ExtractUmisFromBam:

--- a/BALSAMIC/snakemake_rules/umi/fgbio.rule
+++ b/BALSAMIC/snakemake_rules/umi/fgbio.rule
@@ -2,9 +2,8 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 
 rule fgbio_ExtractUmisFromBam:
     input:

--- a/BALSAMIC/snakemake_rules/umi/fgbio_v2.rule
+++ b/BALSAMIC/snakemake_rules/umi/fgbio_v2.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/umi/fgbio_v2.rule
+++ b/BALSAMIC/snakemake_rules/umi/fgbio_v2.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-resultdir = get_result_dir(config) + "/" 
 picarddup = get_picard_mrkdup(config)
 
 rule S_1_convert_Fastq_to_unaligned_bam:

--- a/BALSAMIC/snakemake_rules/umi/picard.rule
+++ b/BALSAMIC/snakemake_rules/umi/picard.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-resultdir = get_result_dir(config) + "/" 
 picarddup = get_picard_mrkdup(config)
 
 def picard_flag(picarddup):

--- a/BALSAMIC/snakemake_rules/umi/picard.rule
+++ b/BALSAMIC/snakemake_rules/umi/picard.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/umi/vardict_single_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/vardict_single_umi.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_caller = "vardict"
 vardict_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/umi/vardict_single_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/vardict_single_umi.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 var_caller = "vardict"

--- a/BALSAMIC/snakemake_rules/variant_calling/bcftools.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/bcftools.rule
@@ -5,7 +5,7 @@ from BALSAMIC.tools import get_vcf_files
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 var_type = "SNV"

--- a/BALSAMIC/snakemake_rules/variant_calling/bcftools.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/bcftools.rule
@@ -5,9 +5,8 @@ from BALSAMIC.tools import get_vcf_files
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_type = "SNV"
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-cnv_dir = get_result_dir(config) + "/cnv/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 rule cnvkit_paired:
   input:

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 rule cnvkit_paired:

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 rule cnvkit_single:

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-cnv_dir = get_result_dir(config) + "/cnv/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 rule cnvkit_single:
   input:

--- a/BALSAMIC/snakemake_rules/variant_calling/freebayes.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/freebayes.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 var_caller = 'freebayes'

--- a/BALSAMIC/snakemake_rules/variant_calling/freebayes.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/freebayes.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = 'freebayes'
 freebayes_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/haplotypecaller.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/haplotypecaller.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 var_caller = "haplotypecaller"

--- a/BALSAMIC/snakemake_rules/variant_calling/haplotypecaller.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/haplotypecaller.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "haplotypecaller"
 haplotypecaller_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 var_caller = "manta"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "manta"
 manta_dir = vcf_dir + var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta_germline.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "manta_germline"
 manta_dir = vcf_dir + var_caller + "_{sample}/"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta_germline.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 var_caller = "manta_germline"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta_single.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env
+from BALSAMIC.tools import get_conda_env
 
 
 var_caller = "manta"

--- a/BALSAMIC/snakemake_rules/variant_calling/manta_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/manta_single.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env
+from BALSAMIC tools import get_conda_env
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "manta"
 manta_dir = vcf_dir + var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -4,9 +4,8 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
 
 rule mergeBam_normal_gatk:

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -4,7 +4,7 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_paired_umi.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_paired_umi.rule
@@ -4,9 +4,8 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
 
 rule mergeBam_normal_gatk:

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_paired_umi.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_paired_umi.rule
@@ -4,7 +4,7 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_single_umi.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_single_umi.rule
@@ -4,7 +4,7 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_single_umi.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_single_umi.rule
@@ -4,9 +4,8 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
 
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -4,7 +4,7 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -4,9 +4,8 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.tools import get_sample_type
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
 picarddup = get_picard_mrkdup(config)
 
 rule mergeBam_tumor:

--- a/BALSAMIC/snakemake_rules/variant_calling/mutect.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mutect.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_caller = "mutect"
 mutect_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/mutect.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mutect.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 var_caller = "mutect"

--- a/BALSAMIC/snakemake_rules/variant_calling/mutect_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mutect_single.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "mutect"
 mutect_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/mutect_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mutect_single.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 var_caller = "mutect"

--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_chrom, get_picard_mrkdup
 
 
 chromlist = get_chrom(config["path"]["panel"] + config["bed"]["capture_kit"])

--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_chrom, get_picard_mrkdup
 
-vcf_dir = get_result_dir(config) + "/vcf/"
-bam_dir = get_result_dir(config) + "/bam/"
 
 chromlist = get_chrom(config["path"]["panel"] + config["bed"]["capture_kit"])
 picarddup = get_picard_mrkdup(config)

--- a/BALSAMIC/snakemake_rules/variant_calling/strelka.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/strelka.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_caller = "strelka"
 strelka_dir = vcf_dir + var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/strelka.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/strelka.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 var_caller = "strelka"

--- a/BALSAMIC/snakemake_rules/variant_calling/strelka_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/strelka_germline.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_picard_mrkdup
+from BALSAMIC.tools import get_conda_env, get_picard_mrkdup
 
 
 var_caller = "strelka_germline"

--- a/BALSAMIC/snakemake_rules/variant_calling/strelka_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/strelka_germline.rule
@@ -3,10 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_picard_mrkdup
+from BALSAMIC tools import get_conda_env, get_picard_mrkdup
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
 
 var_caller = "strelka_germline"
 strelka_dir = vcf_dir + var_caller + "_{sample}/"

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict.rule
@@ -3,14 +3,11 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
 var_caller = "vardict"
 vardict_dir = var_caller + "/"
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 chromlist = get_chrom(config["path"]["panel"] + config["bed"]["capture_kit"])
 

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 var_caller = "vardict"
 vardict_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict_single.rule
@@ -3,11 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.tools import get_result_dir, get_conda_env, get_chrom
+from BALSAMIC tools import get_conda_env, get_chrom
 
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_caller = "vardict"
 vardict_dir = var_caller + "/"

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict_single.rule
@@ -3,7 +3,7 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC tools import get_conda_env, get_chrom
+from BALSAMIC.tools import get_conda_env, get_chrom
 
 
 var_caller = "vardict"

--- a/BALSAMIC/workflows/Alignment
+++ b/BALSAMIC/workflows/Alignment
@@ -8,6 +8,13 @@ from BALSAMIC.tools import get_result_dir
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+bam_dir = get_result_dir(config) + "/bam/"
+cnv_dir = get_result_dir(config) + "/cnv/"
+cutadapt_dir = get_result_dir(config) + "/cutadapt/"
+fastqc_dir = get_result_dir(config) + "/fastqc/"
+result_dir = get_result_dir(config) + "/"
+vcf_dir = get_result_dir(config) + "/vcf/"
+vep_dir = get_result_dir(config) + "/vep/"
 
 include:
   rule_dir + "snakemake_rules/align/bwa_mem.rule"
@@ -37,11 +44,6 @@ include:
   rule_dir + "snakemake_rules/variant_calling/mutect_single.rule"
 include:
   rule_dir + "snakemake_rules/annotation/vep.rule"
-
-
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_type = ["SNV", "SV"]
 rule all:

--- a/BALSAMIC/workflows/VariantCalling_paired
+++ b/BALSAMIC/workflows/VariantCalling_paired
@@ -9,6 +9,13 @@ from BALSAMIC.tools import get_result_dir
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+bam_dir = get_result_dir(config) + "/bam/"
+cnv_dir = get_result_dir(config) + "/cnv/"
+cutadapt_dir = get_result_dir(config) + "/cutadapt/"
+fastqc_dir = get_result_dir(config) + "/fastqc/"
+result_dir = get_result_dir(config) + "/"
+vcf_dir = get_result_dir(config) + "/vcf/"
+vep_dir = get_result_dir(config) + "/vep/"
 
 include:
   rule_dir + "snakemake_rules/align/bwa_mem.rule"
@@ -53,12 +60,7 @@ include:
 #include:
 #  rule_dir + "snakemake_rules/variant_calling/bcftools.rule"
 
-
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
-
-var_type = ["SNV", "SV"]
+ar_type = ["SNV", "SV"]
 var_class = ["somatic", "germline"]
 
 rule all:

--- a/BALSAMIC/workflows/VariantCalling_paired_umi
+++ b/BALSAMIC/workflows/VariantCalling_paired_umi
@@ -8,6 +8,15 @@ from BALSAMIC.tools import get_result_dir, get_vcf
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+bam_dir = get_result_dir(config) + "/bam/"
+cnv_dir = get_result_dir(config) + "/cnv/"
+cutadapt_dir = get_result_dir(config) + "/cutadapt/"
+fastqc_dir = get_result_dir(config) + "/fastqc/"
+result_dir = get_result_dir(config) + "/"
+vcf_dir = get_result_dir(config) + "/vcf/"
+vep_dir = get_result_dir(config) + "/vep/"
+
+include:
 
 include:
   rule_dir + "snakemake_rules/align/bwa_mem_umi.rule"
@@ -25,10 +34,6 @@ include:
   rule_dir + "snakemake_rules/variant_calling/strelka.rule"
 include:
   rule_dir + "snakemake_rules/variant_calling/manta.rule"
-
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_type = ["SNV", "SV"]
 var_class = ["somatic", "germline"]

--- a/BALSAMIC/workflows/VariantCalling_single
+++ b/BALSAMIC/workflows/VariantCalling_single
@@ -11,6 +11,14 @@ shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
 
+bam_dir = get_result_dir(config) + "/bam/"
+cnv_dir = get_result_dir(config) + "/cnv/"
+cutadapt_dir = get_result_dir(config) + "/cutadapt/"
+fastqc_dir = get_result_dir(config) + "/fastqc/"
+result_dir = get_result_dir(config) + "/"
+vcf_dir = get_result_dir(config) + "/vcf/"
+vep_dir = get_result_dir(config) + "/vep/"
+
 include:
   rule_dir + "snakemake_rules/align/bwa_mem.rule"
 include:
@@ -50,10 +58,6 @@ include:
 include:
   rule_dir + "snakemake_rules/annotation/vep.rule"
 
-bam_dir = get_result_dir(config) + "/bam/"
-cnv_dir = get_result_dir(config) + "/cnv/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_type = ["SNV", "SV"]
 var_class = ["somatic", "germline"]

--- a/BALSAMIC/workflows/VariantCalling_single_umi
+++ b/BALSAMIC/workflows/VariantCalling_single_umi
@@ -8,6 +8,13 @@ from BALSAMIC.tools import get_result_dir, get_vcf
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+bam_dir = get_result_dir(config) + "/bam/"
+cnv_dir = get_result_dir(config) + "/cnv/"
+cutadapt_dir = get_result_dir(config) + "/cutadapt/"
+fastqc_dir = get_result_dir(config) + "/fastqc/"
+result_dir = get_result_dir(config) + "/"
+vcf_dir = get_result_dir(config) + "/vcf/"
+vep_dir = get_result_dir(config) + "/vep/"
 
 include:
   rule_dir + "snakemake_rules/umi/fgbio_v2.rule"
@@ -17,10 +24,6 @@ include:
   rule_dir + "snakemake_rules/variant_calling/mergetype_single_umi.rule"
 include:
   rule_dir + "snakemake_rules/umi/vardict_single_umi.rule"
-
-bam_dir = get_result_dir(config) + "/bam/"
-vcf_dir = get_result_dir(config) + "/vcf/"
-vep_dir = get_result_dir(config) + "/vep/"
 
 var_type = ["SNV"]
 var_class = ["somatic", "germline"]


### PR DESCRIPTION
This PR simplifies `get_result_dir` calls by moving them from rules to workflows.

To Test this PR:
1. `git checkout workflow_path_update`
2. `cd tests/test_data`
3. test workflow on dummy files: `balsamic config sample -p references/GRCh37/panel/panel.bed -t fastq/S1_R_1.fastq.gz  --sample-id workflow_path_update --analysis-dir ./ && balsamic run -s workflow_path_update/workflow_path_update.json`
4. This should create the following files:
`workflow_path_update/workflow_path_update.json` and   `workflow_path_update/workflow_path_update.json_BALSAMIC_2.9.8_graph.pdf`. And run without error.