### PR TITLE
Test rule utils

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 #! /usr/bin/python
 
 import pytest
+import yaml
 
+from pathlib import Path
 from functools import partial
 from click.testing import CliRunner
 
@@ -48,6 +50,26 @@ def conda():
         "balsamic-py36": "BALSAMIC/conda/BALSAMIC-py36.yaml",
     }
 
+
+@pytest.fixture(scope='session')
+def BALSAMIC_env(tmp_path_factory):
+    """
+    Writes BALSAMIC_env.yaml file.
+    """
+    # create a conda_env directory
+    conda_env_path = tmp_path_factory.mktemp("conda_env")
+
+    # create a yaml file inside conda_env_path
+    conda_packages = {
+        str("env_1"): ["package_1", "package_2"],
+        str("env_2"): ["package_4"]
+    }
+
+    conda_env_file = conda_env_path / "test_BALSAMIC_env.yaml"
+
+    yaml.dump(conda_packages, open(conda_env_file, 'w'))
+
+    return str(conda_env_file)
 
 @pytest.fixture(scope='session')
 def sample_config():

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 from pathlib import Path
 
@@ -16,6 +17,7 @@ from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_script_path
+from BALSAMIC.utils.rule import get_result_dir
 
 def test_get_ref_path(config_files):
     # GIVEN a sample json file path
@@ -221,17 +223,6 @@ def test_get_sample_type(sample_config):
     assert sample_id == ['S1_R']
 
 
-# def test_get_conda_env(sample_config):
-#     # GIVEN a balsamic_env yaml file path
-#     balsamic_env = "BALSAMIC_env.yaml"
-
-#     # WHEN passing pkg name with this yaml file
-#     conda_env = get_conda_env(balsamic_env, 'ensembl-vep')
-
-#     # THEN It should return the conda env which has that pkg
-#     assert "Cancer-vep" in conda_env
-
-
 def test_get_picard_mrkdup(sample_config):
     # WHEN passing sample_config
     picard_str = get_picard_mrkdup(sample_config)
@@ -260,3 +251,16 @@ def test_createDir(tmp_path):
     assert test_log_dir_created == str(tmp_path / "existing_dir.1")
     assert Path(test_log_dir_created).is_dir()
 
+def test_get_result_dir(sample_config):
+    # WHEN a sample_config dict
+    # GIVEN a sample_config dict
+    # THEN get_result_dir should return result directory
+    assert get_result_dir(sample_config) == os.path.abspath(sample_config["analysis"]["result"]) 
+
+def test_get_conda_env(BALSAMIC_env, tmp_path):
+    # GIVEN a BALSAMIC_env yaml
+    # WHEN passing pkg name with this yaml file
+    conda_env = get_conda_env(BALSAMIC_env, 'package_1')
+
+    # THEN It should return the conda env which has that pkg
+    assert conda_env == "env_1"


### PR DESCRIPTION
This PR adds test for rule utils

1. get_conda_env
2. get_result_dir

How to test:

- `pytest -v tests/utils/test_utils.py::test_get_conda_env`
- `pytest -v tests/utils/test_utils.py::test_get_result_dir`