### PR TITLE
Config-reference command refactored and logging added

### DIFF
--- a/BALSAMIC/commands/base.py
+++ b/BALSAMIC/commands/base.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
         SomAtic MutatIons in Cancer""".format(version=__version__))
 def cli(context):
     "BALSAMIC"
-    coloredlogs.install(level='INFO', fmt='%(asctime)s %(hostname)s %(name)s %(levelname)s %(message)s')
+    coloredlogs.install(level='INFO', fmt='[%(hostname)s] %(asctime)s %(levelname)s %(message)s')
     LOG.info("BALSAMIC started with logger !!")
 
 

--- a/BALSAMIC/commands/base.py
+++ b/BALSAMIC/commands/base.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
         SomAtic MutatIons in Cancer""".format(version=__version__))
 def cli(context):
     "BALSAMIC"
-    coloredlogs.install(level='INFO', fmt='%(asctime)s %(hostname)s %(levelname)s %(message)s')
+    coloredlogs.install(level='INFO', fmt='%(asctime)s %(hostname)s %(name)s %(levelname)s %(message)s')
     LOG.info("BALSAMIC started with logger !!")
 
 

--- a/BALSAMIC/commands/base.py
+++ b/BALSAMIC/commands/base.py
@@ -1,7 +1,9 @@
 """
 Entry cli for balsamic
 """
+import logging
 import click
+import coloredlogs
 
 # Subcommands
 from BALSAMIC.commands.install.install import install as install_command
@@ -14,14 +16,18 @@ from BALSAMIC.utils.cli import add_doc as doc
 # Get version
 from BALSAMIC import __version__
 
+LOG = logging.getLogger(__name__)
+
+
 @click.group()
 @click.version_option(version=__version__)
 @click.pass_context
-
 @doc("""BALSAMIC {version}: Bioinformatic Analysis pipeLine for
         SomAtic MutatIons in Cancer""".format(version=__version__))
 def cli(context):
     "BALSAMIC"
+    coloredlogs.install(level='INFO',fmt='%(asctime)s %(hostname)s %(name)s %(levelname)s %(message)s')
+    LOG.info("BALSAMIC started with logger !!")
 
 
 cli.add_command(install_command)

--- a/BALSAMIC/commands/base.py
+++ b/BALSAMIC/commands/base.py
@@ -17,16 +17,19 @@ from BALSAMIC.utils.cli import add_doc as doc
 from BALSAMIC import __version__
 
 LOG = logging.getLogger(__name__)
+LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 
 
 @click.group()
+@click.option('--loglevel', default='DEBUG', type=click.Choice(LOG_LEVELS),
+              help="Set the level of log output.", show_default=True)
 @click.version_option(version=__version__)
 @click.pass_context
 @doc("""BALSAMIC {version}: Bioinformatic Analysis pipeLine for
         SomAtic MutatIons in Cancer""".format(version=__version__))
-def cli(context):
+def cli(context, loglevel):
     "BALSAMIC"
-    coloredlogs.install(level='INFO', fmt='[%(hostname)s] %(asctime)s %(levelname)s %(message)s')
+    coloredlogs.install(level=loglevel, fmt='[%(hostname)s] %(asctime)s %(levelname)s %(message)s')
     LOG.info("BALSAMIC started with logger !!")
 
 

--- a/BALSAMIC/commands/config/reference.py
+++ b/BALSAMIC/commands/config/reference.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import os
-import sys
 import logging
 import click
 import graphviz
@@ -83,9 +82,9 @@ def reference(outdir, cosmic_key, snakefile, dagfile, singularity,
                                 filename=dagfile_path,
                                 format="pdf",
                                 engine="dot")
-    
+
     if graph_obj.render():
         LOG.info(f'Reference generation workflow configured successfully - {outdir}')
     else:
-        LOG.error(f'Reference generation workflow configure failed - {outdir}')
-        sys.exit()
+        LOG.error(f'Snakemake DAG graph generation failed - {dagfile_path}')
+        click.Abort()

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -339,4 +339,8 @@ def sample(context, umi, install_config, reference_config,
                                 engine="dot")
     #    graph_obj.attr('graph',label='BALSAMIC')
     #    graph_obj.graph_attr['label'] = "_".join(['BALSAMIC',bv,json_out["analysis"]["sample_id"]])
-    graph_obj.render()
+    if graph_obj.render():
+        LOG.info(f'BALSAMIC Workflow has been configured successfully !!- {output_config}')
+    else:
+        LOG.error(f'BALSAMIC Workflow has been failed to configure - {output_config}')
+        sys.exit()

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import sys
 import subprocess
 import re
 import json
@@ -141,10 +140,10 @@ def get_fastq_path(file, fq_pattern):
                 fq_pattern.search(file_basename).span()[0] + 1)]
         except AttributeError as error:
             LOG.error(f"File name is invalid, fastq file should be sample_R_1.fastq.gz")
-            sys.exit()
+            raise click.Abort()
     else:
         LOG.error(f"{file} is not found, update correct file path")
-        sys.exit()
+        raise click.Abort()
 
     return file_str, os.path.split(file)[0]
 
@@ -159,10 +158,6 @@ def configure_fastq(fq_path, sample, fastq_prefix):
     # get a list of fq files
     sample_str, sample_path = get_fastq_path(sample, fq_pattern)
     paths.append(sample_path)
-
-    #    if normal:
-    #        normal_str, normal_path = get_fastq_path(normal, fq_pattern)
-    #        paths.append(normal_path)
 
     fq_files = set()
     for path in paths:
@@ -343,4 +338,4 @@ def sample(context, umi, install_config, reference_config,
         LOG.info(f'BALSAMIC Workflow has been configured successfully !!- {output_config}')
     else:
         LOG.error(f'BALSAMIC Workflow has been failed to configure - {output_config}')
-        sys.exit()
+        raise click.Abort()

--- a/BALSAMIC/commands/config/sample.py
+++ b/BALSAMIC/commands/config/sample.py
@@ -337,5 +337,5 @@ def sample(context, umi, install_config, reference_config,
     if graph_obj.render():
         LOG.info(f'BALSAMIC Workflow has been configured successfully !!- {output_config}')
     else:
-        LOG.error(f'BALSAMIC Workflow has been failed to configure - {output_config}')
+        LOG.error(f'BALSAMIC dag graph generation failed - {dag_image}')
         raise click.Abort()

--- a/BALSAMIC/commands/run/analysis.py
+++ b/BALSAMIC/commands/run/analysis.py
@@ -96,11 +96,11 @@ def analysis(context, snake_file, sample_config, run_mode, cluster_config,
     """
 
     if run_mode == 'slurm' and not run_analysis:
-        click.echo('Changing run-mode to local on dry-run')
+        LOG.info('Changing run-mode to local on dry-run')
         run_mode = 'local'
 
     if run_mode == 'slurm' and not slurm_account:
-        click.echo('slurm account is required for slurm run mode')
+        LOG.info('slurm account is required for slurm run mode')
         raise click.Abort()
 
     sample_config_path = os.path.abspath(sample_config)

--- a/BALSAMIC/commands/run/analysis.py
+++ b/BALSAMIC/commands/run/analysis.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import logging
 import subprocess
 import json
 import click
@@ -9,6 +10,9 @@ from BALSAMIC.utils.cli import createDir
 from BALSAMIC.utils.cli import get_sbatchpy
 from BALSAMIC.utils.cli import get_snakefile, SnakeMake
 from BALSAMIC.utils.cli import get_config
+
+
+LOG = logging.getLogger(__name__)
 
 
 @click.command("analysis", short_help="Run the analysis on a provided sample config-file")

--- a/BALSAMIC/commands/run/reference.py
+++ b/BALSAMIC/commands/run/reference.py
@@ -2,10 +2,13 @@
 
 import json
 import subprocess
+import logging
 import click
 
 from BALSAMIC.utils.cli import get_sbatchpy
 from BALSAMIC.utils.cli import get_snakefile, SnakeMake, get_config
+
+LOG = logging.getLogger(__name__)
 
 
 @click.command('reference', short_help="Run the GenerateRef workflow")
@@ -59,7 +62,7 @@ from BALSAMIC.utils.cli import get_snakefile, SnakeMake, get_config
 def reference(context, snakefile, configfile, run_mode, cluster_config,
               log_file, run_analysis, qos, force_all, snakemake_opt):
     """ Run generate reference workflow """
-    click.echo("Reference generation workflow started")
+    LOG.info("Reference generation workflow started")
 
     with open(configfile, "r") as config_fh:
         config = json.load(config_fh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ click
 pyyaml
 yapf
 graphviz
+coloredlogs
 snakemake==5.5.1

--- a/tests/commands/config/test_config_reference.py
+++ b/tests/commands/config/test_config_reference.py
@@ -13,7 +13,7 @@ def test_config_reference_write_json(install_config, invoke_cli, tmp_path):
 
     # WHEN creating config.json in reference dir
     test_output_reference_config = test_new_dir / "config.json"
-    test_output_reference_pdf = test_new_dir / "generate_ref_dag.pdf"
+    test_output_reference_pdf = test_new_dir / "generate_ref_worflow_graph.pdf"
 
     result = invoke_cli([
         'config', 'reference', '-i', install_config, '-c', 'secret_key', '-o',

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -241,7 +241,7 @@ def test_get_fastq_path(sample_fastq):
 
 
 def test_get_fastq_path_error(sample_fastq):
-    with pytest.raises(Exception) as error:
+    with pytest.raises(SystemExit) as exit:
         # GIVEN a fastq file path, and file pattern
         fastq_prefix = ''
         fastq_file = 'S1_R_1.fastq.gz'
@@ -250,11 +250,11 @@ def test_get_fastq_path_error(sample_fastq):
         # WHEN invoking get fastq path
         # THEN It should return fileprefix and fastq_path
         assert get_fastq_path(fastq_file, fq_pattern)
-        assert 'FileNotFoundError' in error.value
+        assert exit.type == SystemExit
 
 
 def test_get_fqpath_mismatch_error(sample_fastq):
-    with pytest.raises(Exception) as error:
+    with pytest.raises(SystemExit) as exit:
         # GIVEN a fastq file path, and file pattern
         fastq_prefix = ''
         fastq_file = sample_fastq['fastq_invalid']
@@ -263,6 +263,6 @@ def test_get_fqpath_mismatch_error(sample_fastq):
         # WHEN invoking get fastq path
         # THEN It should return fileprefix and fastq_path
         assert get_fastq_path(fastq_file, fq_pattern)
-        assert 'AttributeError' in error.value
+        assert exit.type == SystemExit
 
 

--- a/tests/commands/config/test_config_sample.py
+++ b/tests/commands/config/test_config_sample.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from datetime import datetime
 from pathlib import Path
+import click
 
 from BALSAMIC.commands.config.sample import merge_json, \
     set_panel_bed, get_output_config, get_sample_config, get_analysis_type, \
@@ -200,7 +201,7 @@ def test_get_fastq_path(sample_fastq):
 
 
 def test_get_fastq_path_error(sample_fastq):
-    with pytest.raises(SystemExit) as exit:
+    with pytest.raises(click.Abort):
         # GIVEN a fastq file path, and file pattern
         fastq_prefix = ''
         fastq_file = 'S1_R_1.fastq.gz'
@@ -209,11 +210,10 @@ def test_get_fastq_path_error(sample_fastq):
         # WHEN invoking get fastq path
         # THEN It should return fileprefix and fastq_path
         assert get_fastq_path(fastq_file, fq_pattern)
-        assert exit.type == SystemExit
 
 
 def test_get_fqpath_mismatch_error(sample_fastq):
-    with pytest.raises(SystemExit) as exit:
+    with pytest.raises(click.Abort):
         # GIVEN a fastq file path, and file pattern
         fastq_prefix = ''
         fastq_file = sample_fastq['fastq_invalid']
@@ -222,7 +222,6 @@ def test_get_fqpath_mismatch_error(sample_fastq):
         # WHEN invoking get fastq path
         # THEN It should return fileprefix and fastq_path
         assert get_fastq_path(fastq_file, fq_pattern)
-        assert exit.type == SystemExit
 
 
 def test_config_sample_tumor_normal(tmp_path, sample_fastq, analysis_dir,


### PR DESCRIPTION
**This PR contains,**
- subprocess shell cmd execution removed from config-reference
- snakemake and graphviz module used to generate dag image file
- logging and coloredlogs added to BALSAMIC

**How to test**
- clone the repo, checkout to config branch
- Run pytest on tests dir

**Expected outcome**
- Testcases should run without error
- While running commands, logs should be shown