### PR TITLE
MD5 string generation in GenerateRef

### DIFF
--- a/BALSAMIC/workflows/GenerateRef
+++ b/BALSAMIC/workflows/GenerateRef
@@ -4,10 +4,13 @@
 
 import os
 import hashlib
+from datetime import date
 
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_script_path
 
+
+current_day = date.today()
 
 # LINKS TO REFERENCE FILES
 # ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/
@@ -25,7 +28,7 @@ refgene_sql_url = "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refGe
 VCF = ['dbsnp_grch37_b138.vcf', '1k_genome_wgs_p1_v3_all_sites.vcf',
        '1kg_phase1_snps_high_confidence_b37.vcf', 'mills_1kg_index.vcf', 'cosmic_coding_muts_v89.vcf']
 
-basedir = config['output'] + '/GRCh37'
+basedir = os.path.join(config['output'], 'GRCh37')
 genome_dir = basedir + "/genome/"
 vcf_dir = basedir + "/variants/"
 vep_dir = basedir + "/vep/"
@@ -45,7 +48,7 @@ hc_vcf_1kg = os.path.join(vcf_dir, "1kg_phase1_snps_high_confidence_b37.vcf")
 known_indel_1kg = os.path.join(vcf_dir, "1kg_known_indels_b37.vcf.gz")
 mills_1kg = os.path.join(vcf_dir, "mills_1kg_index.vcf")
 cosmicdb = os.path.join(vcf_dir, "cosmic_coding_muts_v89.vcf")
-check_md5 = os.path.join(basedir, "reference_check.md5")
+check_md5 = os.path.join(basedir, "reference_" + str(current_day) + ".md5")
 
 # list of reference download link and output file name
 ref_list = [(reference_genome_url, reference_genome), (vcf_1kg_url, vcf_1kg), (dbsnp_url, dbsnp),
@@ -118,7 +121,7 @@ rule all:
 
         with open(str(output.reference_json), "w") as fh:
             json.dump(ref_json, fh, indent=4)
-
+        
         create_md5(ref_json['reference'], output.check_md5)
 
         shell("date +'%Y-%M-%d T%T %:z' > {output.finished}") 

--- a/BALSAMIC/workflows/GenerateRef
+++ b/BALSAMIC/workflows/GenerateRef
@@ -2,6 +2,9 @@
 # syntax=python tabstop=4 expandtab
 # coding: utf-8
 
+import os
+import hashlib
+
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_script_path
 
@@ -23,7 +26,7 @@ refgene_sql_url = "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refGe
 VCF = ['dbsnp_grch37_b138.vcf', '1k_genome_wgs_p1_v3_all_sites.vcf',
        '1kg_phase1_snps_high_confidence_b37.vcf', 'mills_1kg_index.vcf', 'cosmic_coding_muts_v89.vcf']
 
-basedir = config['output']
+basedir = config['output'] + '/GRCh37'
 genome_dir = basedir + "/genome/"
 vcf_dir = basedir + "/variants/"
 vep_dir = basedir + "/vep/"
@@ -49,6 +52,23 @@ ref_list = [(reference_genome_url, reference_genome), (vcf_1kg_url, vcf_1kg), (d
             (hc_vcf_1kg_url,hc_vcf_1kg), (mills_1kg_url, mills_1kg), (known_indel_1kg_url, known_indel_1kg)]
 
 shell.prefix("set -eo pipefail; ")
+
+
+def get_md5(filename):
+    hash_md5 = hashlib.md5()
+    with open(str(filename), 'rb') as fh:
+        for chunk in iter(lambda: fh.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def create_md5(reference):
+    """ create a md5 file for all reference data"""
+    with open(basedir + '/reference_check.md5', 'w') as fh:
+        for key, value in reference.items():
+            if os.path.isfile(value):
+                fh.write( get_md5(value) + ' ' + value + '\n')
+
 
 if 'singularity' in config:
     singularity: config['singularity']
@@ -97,6 +117,8 @@ rule all:
 
         with open(str(output.reference_json), "w") as fh:
             json.dump(ref_json, fh, indent=4)
+
+        create_md5(ref_json['reference'])
 
         shell("date +'%Y-%M-%d T%T %:z' > {output.finished}") 
 

--- a/BALSAMIC/workflows/GenerateRef
+++ b/BALSAMIC/workflows/GenerateRef
@@ -8,7 +8,6 @@ import hashlib
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_script_path
 
-__author__ = "Sarath Murugan"
 
 # LINKS TO REFERENCE FILES
 # ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/
@@ -46,6 +45,7 @@ hc_vcf_1kg = os.path.join(vcf_dir, "1kg_phase1_snps_high_confidence_b37.vcf")
 known_indel_1kg = os.path.join(vcf_dir, "1kg_known_indels_b37.vcf.gz")
 mills_1kg = os.path.join(vcf_dir, "mills_1kg_index.vcf")
 cosmicdb = os.path.join(vcf_dir, "cosmic_coding_muts_v89.vcf")
+check_md5 = os.path.join(basedir, "reference_check.md5")
 
 # list of reference download link and output file name
 ref_list = [(reference_genome_url, reference_genome), (vcf_1kg_url, vcf_1kg), (dbsnp_url, dbsnp),
@@ -62,9 +62,9 @@ def get_md5(filename):
     return hash_md5.hexdigest()
 
 
-def create_md5(reference):
+def create_md5(reference, check_md5):
     """ create a md5 file for all reference data"""
-    with open(basedir + '/reference_check.md5', 'w') as fh:
+    with open(check_md5, 'w') as fh:
         for key, value in reference.items():
             if os.path.isfile(value):
                 fh.write( get_md5(value) + ' ' + value + '\n')
@@ -90,13 +90,14 @@ rule all:
         th_genome_vcf = vcf_1kg + ".gz",
         tg_high_vcf = hc_vcf_1kg + ".gz",
         mills_1kg = mills_1kg + ".gz",
-        known_indel_1kg = mills_1kg + ".gz",
+        known_indel_1kg = known_indel_1kg + ".gz",
         cosmic_vcf = cosmicdb + ".gz",
         variants_idx = expand( vcf_dir + "{vcf}.gz.tbi", vcf=VCF),
         vep = vep_dir
     output:
         finished = os.path.join(basedir,"reference.finished"),
-        reference_json = reference_json
+        reference_json = reference_json,
+        check_md5 = check_md5
     log:
         reference_json + ".log"
     run:
@@ -118,7 +119,7 @@ rule all:
         with open(str(output.reference_json), "w") as fh:
             json.dump(ref_json, fh, indent=4)
 
-        create_md5(ref_json['reference'])
+        create_md5(ref_json['reference'], output.check_md5)
 
         shell("date +'%Y-%M-%d T%T %:z' > {output.finished}") 
 


### PR DESCRIPTION
This PR contains,
- md5 string generations added to GenerateRef workflow
- Genome version eg: `GRCh37` directory added to `basedir` 
- Fixed - variable name for known_indel_1kg

