### PR TITLE
RG update post merging bam files of same type

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -8,16 +8,23 @@ from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
 
+picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
+picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
+
 rule mergeBam_normal_gatk:
   input:
     bamN = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "normal")),
   output:
     bamN = bam_dir + "normal.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_normal
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamN} {input.bamN}; samtools index {output.bamN}; "
+    "samtools merge {output.bamN}.tmp {input.bamN}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamN}.tmp OUTPUT={output.bamN}; "
+    "samtools index {output.bamN}; "
+    "rm {output.bamN}.tmp; "
     "source deactivate; "
 
 rule mergeBam_normal:
@@ -26,22 +33,14 @@ rule mergeBam_normal:
   output:
     bamN = bam_dir + "normal.merged.bam", 
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_normal
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamN} {input.bamN}; samtools index {output.bamN}; "
-    "source deactivate; "
-
-rule mergeBam_tumor_gatk:
-  input:
-    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "tumor"))
-  output:
-    bamT = bam_dir + "tumor.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
-  params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
-  shell:
-    "source activate {params.conda}; "
-    "samtools merge {output.bamT} {input.bamT}; samtools index {output.bamT}; "
+    "samtools merge {output.bamN}.tmp {input.bamN}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamN}.tmp OUTPUT={output.bamN}; "
+    "samtools index {output.bamN}; "
+    "rm {output.bamN}.tmp; "
     "source deactivate; "
 
 rule mergeBam_tumor:
@@ -50,8 +49,28 @@ rule mergeBam_tumor:
   output:
     bamT = bam_dir + "tumor.merged.bam",
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_tumor
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT} {input.bamT}; samtools index {output.bamT}; "
+    "samtools merge {output.bamT}.tmp {input.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "samtools index {output.bamT}; "
+    "rm {output.bamT}.tmp; "
+    "source deactivate; "
+
+rule mergeBam_tumor_gatk:
+  input:
+    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "tumor"))
+  output:
+    bamT = bam_dir + "tumor.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
+  params:
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_tumor
+  shell:
+    "source activate {params.conda}; "
+    "samtools merge {output.bamT}.tmp {input.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "samtools index {output.bamT}; "
+    "rm {output.bamT}.tmp; "
     "source deactivate; "

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -7,6 +7,8 @@ from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
 
 picarddup = get_picard_mrkdup(config)
+picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
+picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 
 rule mergeBam_tumor:
   input:
@@ -14,10 +16,14 @@ rule mergeBam_tumor:
   output:
     bamT = bam_dir + "tumor.merged.bam",
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_tumor
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT} {input.bamT}; samtools index {output.bamT}; "
+    "samtools merge {output.bamT}.tmp {input.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "samtools index {output.bamT}; "
+    "rm {output.bamT}.tmp; "
     "source deactivate; "
 
 rule mergeBam_tumor_gatk:
@@ -26,8 +32,12 @@ rule mergeBam_tumor_gatk:
   output:
     bamT = bam_dir + "tumor.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"samtools")
+    conda = get_conda_env(config["conda_env_yaml"],"picard"),
+    picard=picard_extra_tumor
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT} {input.bamT}; samtools index {output.bamT}; "
+    "samtools merge {output.bamT}.tmp {input.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "samtools index {output.bamT}; "
+    "rm {output.bamT}.tmp; "
     "source deactivate; "


### PR DESCRIPTION
This PR updates RG tags (PU, ID, SM, and PL) post merging to simplify unifying VCF merge in downstream analysis.

How to test:
- All unittests should pass.

Expected outcome:
- `normal.merged.bam` and `tumor.merged.bam` should have NORMAL and TUMOR as their RGSM

