### PR TITLE
Vep cosmic

### DIFF
--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -8,7 +8,8 @@ from BALSAMIC.utils.rule import get_conda_env
 
 rule vep:
   input:
-    vcf_dir + "{type}.{mutation}.{sample}.{caller}.vcf.gz"
+    vcf = vcf_dir + "{type}.{mutation}.{sample}.{caller}.vcf.gz",
+    cosmic = config["reference"]["cosmic"]
   output:
     vep = vep_dir + "{type}.{mutation}.{sample}.{caller}.vcf",
     vcf = vep_dir + "{type}.{mutation}.{sample}.{caller}.vcf.gz"
@@ -23,7 +24,7 @@ rule vep:
         "--dir $vep_path "
         "--dir_cache {params.vep_cache} "
         "--dir_plugins $vep_path "
-        "--input_file {input} "
+        "--input_file {input.vcf} "
         "--output_file {output.vep} "
         "--fork {threads} "
         "--vcf "
@@ -33,6 +34,7 @@ rule vep:
         "--variant_class "
         "--merged "
         "--cache "
+        "--custom {input.cosmic},COSMIC,vcf,exact,0,CDS,GENE,STRAND,CNT,AA "
         "--verbose "
         "--force_overwrite && "
     "bgzip -f -c {output.vep} > {output.vcf} && "

--- a/BALSAMIC/workflows/VariantCalling
+++ b/BALSAMIC/workflows/VariantCalling
@@ -82,8 +82,8 @@ var_type = ["SNV", "SV"]
 rule all:
     input:
         os.path.join(*([result_dir + "qc/" + "multiqc_report.html"])),
-        expand(vcf_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, somatic_caller, [config["analysis"]["case_id"]])),
-        expand(vcf_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, germline_caller, config["samples"])),
+        expand(vep_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, somatic_caller, [config["analysis"]["case_id"]])),
+        expand(vep_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, germline_caller, config["samples"])),
         cnvkit_output
     output:
         os.path.join(get_result_dir(config), "analysis_finish")


### PR DESCRIPTION
### This PR:

- Updates VEP annotation format with custom cosmic tags

### How to test:

- Automatic and continuous test pass

### Expected outcome:

- The following tags should be added to CSQ field in INFO after annotation:
`COSMIC|COSMIC_CDS|COSMIC_GENE|COSMIC_STRAND|COSMIC_CNT|COSMIC_AA`

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [x] Tests pass
