### PR TITLE
Sentieon T/N and Tumor only pipeline updated 

### DIFF
--- a/BALSAMIC/commands/config/case.py
+++ b/BALSAMIC/commands/config/case.py
@@ -106,6 +106,7 @@ def get_sample_config(sample_config, case_id, analysis_dir, analysis_type):
                                                        'scripts/')
     sample_config["analysis"]["result"] = os.path.join(analysis_dir, case_id,
                                                        'analysis')
+    sample_config["analysis"]["benchmark"] = os.path.join(analysis_dir, case_id, 'benchmarks/')
     sample_config["analysis"]["analysis_type"] = analysis_type
     sample_config["samples"] = {}
 

--- a/BALSAMIC/commands/run/analysis.py
+++ b/BALSAMIC/commands/run/analysis.py
@@ -121,13 +121,15 @@ def analysis(context, snake_file, sample_config, run_mode, cluster_config,
             if files:
                 logpath = createDir(logpath, [])
                 scriptpath = createDir(scriptpath, [])
+                benchmarkpath = createDir(benchmarkpath, [])
 
     # Create result directory
     os.makedirs(resultpath, exist_ok=True)
-    os.makedirs(benchmarkpath, exist_ok=True)
+
     if not os.path.exists(logpath):
         os.makedirs(logpath, exist_ok=True)
         os.makedirs(scriptpath, exist_ok=True)
+        os.makedirs(benchmarkpath, exist_ok=True)
 
     if not analysis_type:
         analysis_type = sample_config['analysis']['analysis_type']

--- a/BALSAMIC/commands/run/analysis.py
+++ b/BALSAMIC/commands/run/analysis.py
@@ -111,6 +111,7 @@ def analysis(context, snake_file, sample_config, run_mode, cluster_config,
     logpath = sample_config['analysis']['log']
     scriptpath = sample_config['analysis']['script']
     resultpath = sample_config['analysis']['result']
+    benchmarkpath = sample_config['analysis']['benchmark']
     case_name = sample_config['analysis']['case_id']
     sequencing_type = sample_config['analysis']['sequencing_type']
 
@@ -123,6 +124,7 @@ def analysis(context, snake_file, sample_config, run_mode, cluster_config,
 
     # Create result directory
     os.makedirs(resultpath, exist_ok=True)
+    os.makedirs(benchmarkpath, exist_ok=True)
     if not os.path.exists(logpath):
         os.makedirs(logpath, exist_ok=True)
         os.makedirs(scriptpath, exist_ok=True)

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -2,7 +2,7 @@
     "__default__": {
         "name": "BALSAMIC.{rule}.{wildcards}",
         "time": "12:00:00",
-        "n": 8,
+        "n": 16,
         "mail_type": "FAIL",
         "partition": "core"
     },

--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -19,6 +19,8 @@ rule bwa_mem:
     header_1 = "'@RG\\tID:" +  "{sample}" + "\\tSM:" + "{sample}" + "\\tPL:ILLUMINAi'",
     conda = get_conda_env(config["conda_env_yaml"],"bwa")
   threads: 4
+  benchmark:
+    benchmark_dir + "{sample}.bwa_mem.tsv"
   shell:
     "source activate {params.conda}; "
     "bwa mem "

--- a/BALSAMIC/snakemake_rules/align/samtools.rule
+++ b/BALSAMIC/snakemake_rules/align/samtools.rule
@@ -14,6 +14,8 @@ rule samtools_sort_index:
   params:
     conda = get_conda_env(config["conda_env_yaml"],"samtools") 
   threads: 4
+  benchmark:
+    benchmark_dir + '{sample}.samtools_sort.tsv'
   shell:
     "source activate {params.conda}; "
     "samtools sort -@ {threads} -o {output} {input}; "

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -17,6 +17,8 @@ rule vep:
     conda = get_conda_env(config["conda_env_yaml"],"ensembl-vep"),
     vep_cache = config["reference"]["vep"]
   threads: 4
+  benchmark:
+    benchmark_dir + "{type}.{mutation}.{sample}.{caller}.vep.tsv"
   shell:
     "source activate {params.conda}; "
     "vep_path=$(dirname $(readlink -e $(which vep))); "

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -16,6 +16,8 @@ rule RealignerTargetCreator:
     bam_dir + "{sample}.sorted." + picarddup + ".intervals",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"gatk"),
+  benchmark:
+    benchmark_dir + "{sample}.realign_targetcreator.tsv"
   shell:
     "source activate {params.conda}; "
     "gatk3 "
@@ -36,6 +38,8 @@ rule IndelRealigner:
     bam_dir + "{sample}.sorted." + picarddup + ".ralgn.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"gatk"),
+  benchmark:
+    benchmark_dir + "{sample}.indel_realign.tsv"
   shell:
     "source activate {params.conda}; "
     "gatk3 "
@@ -55,7 +59,9 @@ rule BaseRecalibrator:
   output:
     bam_dir + "{sample}.sorted." + picarddup + ".ralgn.bsrcl.bam",
   params:
-    conda = get_conda_env(config["conda_env_yaml"],"gatk"),
+    conda = get_conda_env(config["conda_env_yaml"],"gatk")
+  benchmark:
+    benchmark_dir + "{sample}.base_recalibrator.tsv"
   shell:
     "source activate {params.conda}; "
     "gatk3 "
@@ -82,6 +88,8 @@ rule PreparePopVCF:
     conda = get_conda_env(config["conda_env_yaml"],"bcftools"),
     anno_str1 = "FORMAT/GT,FORMAT/GL,FORMAT/DS,^INFO/AC,^INFO/AF,^INFO/AN,^INFO/",
     popcode = "EUR"
+  benchmark:
+    benchmark_dir + "tumor_prepare_pop_vcf.tsv"
   shell:
     "source activate {params.conda}; "
     "readlink -e {input.bam}; "

--- a/BALSAMIC/snakemake_rules/quality_control/contest.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/contest.rule
@@ -20,6 +20,8 @@ rule GATK_contest:
     conda = get_conda_env(config["conda_env_yaml"],"gatk"),
     min_genotype_ratio="0.95",
     popcode = "EUR"
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".markduplicates.tsv"
   shell:
     "source activate {params.conda}; "
     "gatk3 "

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -6,6 +6,8 @@ __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.utils.rule import get_conda_env
 
+qc_dir = result_dir + "qc/"
+
 if 'quality_trim' in config['QC'].keys():
     fastp_param = list()
     if config['QC']['quality_trim']:
@@ -31,9 +33,10 @@ rule fastp:
   output:
     read1 = fastq_dir + "{sample}_1.fp.fastq.gz",
     read2 = fastq_dir + "{sample}_2.fp.fastq.gz",
+    json_out = qc_dir + "{sample}_fastp.json",
+    html_out = qc_dir + "{sample}_fastp.html"
   params:
     fastq_dir = fastq_dir,
-    qc_dir = result_dir + "qc",
     extra = fastp_param,
     conda = get_conda_env(config["conda_env_yaml"],"fastp")
   benchmark:
@@ -43,8 +46,8 @@ rule fastp:
     "fastp "
     "--in1 {input.read1} --in2 {input.read2} "
     "--out1 {output.read1} --out2 {output.read2} "
-    "--json {params.qc_dir}/fastp.json "
+    "--json {output.json_out} "
     "--overrepresentation_analysis "
     "{params.extra} "
-    "--html {params.qc_dir}/fastp.html; "
+    "--html {output.html_out} ; "
     "source deactivate;"

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -40,7 +40,7 @@ rule fastp:
     extra = fastp_param,
     conda = get_conda_env(config["conda_env_yaml"],"fastp")
   benchmark:
-    fastq_dir + "benchmarks/{sample}_fastp.tsv"
+    benchmark_dir + "{sample}_fastp.tsv"
   shell:
     "source activate {params.conda}; "
     "fastp "

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -36,6 +36,8 @@ rule fastp:
     qc_dir = result_dir + "qc",
     extra = fastp_param,
     conda = get_conda_env(config["conda_env_yaml"],"fastp")
+  benchmark:
+    fastq_dir + "benchmarks/{sample}_fastp.tsv"
   shell:
     "source activate {params.conda}; "
     "fastp "

--- a/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
@@ -17,6 +17,8 @@ rule fastqc:
   params:
     conda = get_conda_env(config["conda_env_yaml"],"fastqc"),
     fastqc_dir=fastqc_dir
+  benchmark:
+    benchmark_dir + "{sample}.fastqc.tsv"
   shell:
     "source activate {params.conda};"
     "fastqc {input.read1} --outdir {params.fastqc_dir};" 

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -23,6 +23,8 @@ rule collectqc:
     dir_list = "\n".join([bam_dir, fastqc_dir]),
     qc_dir = result_dir + "qc/",
     conda = get_conda_env(config["conda_env_yaml"],"multiqc"),
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".multiqc.tsv"
   shell:
     "source activate {params.conda};"
     "echo -e \"{params.dir_list}\" > {params.qc_dir}/dir_list; "

--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -24,6 +24,8 @@ rule MarkDuplicates:
     tmpdir=bam_dir,
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
     rm_dup = picard_flag(picarddup)
+  benchmark:
+    benchmark_dir + "{sample}.markduplicates.tsv"
   shell:
     "source activate {params.conda};"
     "java -jar -Djava.io.tmpdir={params.tmpdir} -Xms8G -Xmx16G $CONDA_PREFIX/share/picard-2.18.11.jar "
@@ -49,6 +51,8 @@ rule CollectHsMetrics:
   params:
     tmpdir=bam_dir,
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
+  benchmark:
+    benchmark_dir + "{sample}.collect_hsmetrics.tsv"
   shell:
     "source activate {params.conda};"
     "java -jar -Djava.io.tmpdir={params.tmpdir} -Xms8G -Xmx16G $CONDA_PREFIX/share/picard-2.18.11.jar "
@@ -84,6 +88,8 @@ rule CollectAlignmentSummaryMetrics:
     tmpdir=bam_dir,
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
     adapter = config["QC"]["adapter"]
+  benchmark:
+    benchmark_dir + "{sample}.collect_alignment_summary.tsv"
   shell:
     "source activate {params.conda};"
     "java -jar -Djava.io.tmpdir={params.tmpdir} -Xms8G -Xmx16G $CONDA_PREFIX/share/picard-2.18.11.jar "
@@ -105,6 +111,8 @@ rule CollectInsertSizeMetrics:
   params:
     tmpdir=bam_dir,
     conda = get_conda_env(config["conda_env_yaml"],"picard")
+  benchmark:
+    benchmark_dir + "{sample}.collect_insertsize_metrics.tsv"
   shell:
     "source activate {params.conda};"
     "java -jar -Djava.io.tmpdir={params.tmpdir} -Xms8G -Xmx16G $CONDA_PREFIX/share/picard-2.18.11.jar "

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -20,6 +20,8 @@ rule sambamba_panel_depth:
     cov_step=50,
     filter_string="'not (unmapped or mate_is_unmapped) and not duplicate and not failed_quality_control and mapping_quality > 10'",
     conda = get_conda_env(config["conda_env_yaml"],"sambamba")
+  benchmark:
+    benchmark_dir + "{sample}.sambamba_panel_depth.tsv"
   shell:
     "source activate {params.conda}; "
     "covStr=`seq {params.cov_start} {params.cov_step} {params.cov_end} | xargs -n1 echo -n \" --cov-threshold\"`; "
@@ -45,6 +47,8 @@ rule sambamba_exon_depth:
     cov_5="250",
     filter_string="'not (unmapped or mate_is_unmapped) and not duplicate and not failed_quality_control and mapping_quality > 10'",
     conda = get_conda_env(config["conda_env_yaml"],"sambamba")
+  benchmark:
+    benchmark_dir + "{sample}.sambamba_exon_depth.tsv"
   shell:
     "source activate {params.conda}; "
     "sambamba depth region "

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
@@ -22,7 +22,7 @@ rule sentieon_align_sort:
     log:
         bam_dir + "{sample}.bam.log"
     benchmark:
-        bam_dir + "benchmarks/{sample}.align_sort.tsv"
+        benchmark_dir + "{sample}.align_sort.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -45,7 +45,7 @@ rule sentieon_dedup:
     log:
         bam_dir + "{sample}.dedup.bam.log"
     benchmark:
-        bam_dir + "benchmarks/{sample}.dedup.tsv"
+        benchmark_dir + "{sample}.dedup.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -71,7 +71,7 @@ rule sentieon_realign:
     log:
         bam_dir + "{sample}.dedup.realign.bam.log"
     benchmark:
-        bam_dir + "benchmarks/{sample}.dedup_realign.tsv"
+        benchmark_dir + "{sample}.dedup_realign.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -98,7 +98,7 @@ rule sentieon_base_calibration:
     log:
         bam_dir + "{sample}.dedup.realign.recal.log"
     benchmark:
-        bam_dir + "benchmarks/{sample}.base_recal.tsv"
+        benchmark_dir + "{sample}.base_recal.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
@@ -21,6 +21,8 @@ rule sentieon_align_sort:
     threads: 16
     log:
         bam_dir + "{sample}.bam.log"
+    benchmark:
+        bam_dir + "benchmarks/{sample}.align_sort.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -42,6 +44,8 @@ rule sentieon_dedup:
     threads: 16
     log:
         bam_dir + "{sample}.dedup.bam.log"
+    benchmark:
+        bam_dir + "benchmarks/{sample}.dedup.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -66,6 +70,8 @@ rule sentieon_realign:
     threads: 16
     log:
         bam_dir + "{sample}.dedup.realign.bam.log"
+    benchmark:
+        bam_dir + "benchmarks/{sample}.dedup_realign.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -91,6 +97,8 @@ rule sentieon_base_calibration:
     threads: 16
     log:
         bam_dir + "{sample}.dedup.realign.recal.log"
+    benchmark:
+        bam_dir + "benchmarks/{sample}.base_recal.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -9,7 +9,7 @@ rule sentieon_DNAscope:
         bam = bam_dir + "{sample}.dedup.realign.bam",
         recal_table = bam_dir + "{sample}.dedup.realign.recal_data.table"
     output:
-        vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz",
+        vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz",
     params:
         sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
         sentieon_lic = SENTIEON_LICENSE, 
@@ -17,6 +17,8 @@ rule sentieon_DNAscope:
     threads: 16
     log: 
         vcf_dir + "{sample}.dnascope.log"
+    benchmark:
+        vcf_dir + "benchmarks/{sample}.dnascope.tsv"
     shell:
     	"""
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -25,23 +27,23 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 		"""
 
 
-rule sentieon_filter_DNAscope:
-    input:
-        ref = config["reference"]["reference_genome"],
-        dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
-    output:
-        dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
-    params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        sentieon_ml_dnascope = SENTIEON_DNASCOPE
-    threads: 16
-    log:
-        vcf_dir + "{sample}.dnascope.filtered.log"
-    shell:
-        """
-export SENTIEON_LICENSE={params.sentieon_lic};
-
-{params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
-        """
-
+#rule sentieon_filter_DNAscope:
+#    input:
+#        ref = config["reference"]["reference_genome"],
+#        dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
+#    output:
+#        dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
+#    params:
+#        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+#        sentieon_lic = SENTIEON_LICENSE, 
+#        sentieon_ml_dnascope = SENTIEON_DNASCOPE
+#    threads: 16
+#    log:
+#        vcf_dir + "{sample}.dnascope.filtered.log"
+#    shell:
+#        """
+#export SENTIEON_LICENSE={params.sentieon_lic};
+#
+#{params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
+#        """
+#

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -22,8 +22,9 @@ rule sentieon_DNAscope:
     shell:
     	"""
 export SENTIEON_LICENSE={params.sentieon_lic};
+export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal_table} --algo DNAscope -d {input.dbsnp} {output.vcf}
+{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} --algo DNAscope -d {input.dbsnp} --pcr_indel_model NONE --model {params.sentieon_ml_dnascope} {output.vcf}
 		"""
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -9,7 +9,7 @@ rule sentieon_DNAscope:
         bam = bam_dir + "{sample}.dedup.realign.bam",
         recal_table = bam_dir + "{sample}.dedup.realign.recal_data.table"
     output:
-        vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz",
+        vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz",
     params:
         sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
         sentieon_lic = SENTIEON_LICENSE, 
@@ -18,36 +18,36 @@ rule sentieon_DNAscope:
     log: 
         vcf_dir + "{sample}.dnascope.log"
     benchmark:
-        vcf_dir + "benchmarks/{sample}.dnascope.tsv"
+        benchmark_dir + "{sample}.dnascope.tsv"
     shell:
     	"""
 export SENTIEON_LICENSE={params.sentieon_lic};
 export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} --algo DNAscope -d {input.dbsnp} --pcr_indel_model NONE --model {params.sentieon_ml_dnascope} {output.vcf}
+{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal_table} --algo DNAscope -d {input.dbsnp} {output.vcf}
 		"""
 
 
-rule sentieon_filter_DNAscope:
-    input:
-        ref = config["reference"]["reference_genome"],
-        dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
-    output:
-        dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
-    params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        sentieon_ml_dnascope = SENTIEON_DNASCOPE
-    threads: 16
-    log:
-        vcf_dir + "{sample}.dnascope.filtered.log"
-    benchmark:
-        vcf_dir + "benchmarks/{sample}.dnascope_filter.tsv"
-    shell:
-        """
-export SENTIEON_LICENSE={params.sentieon_lic};
-export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
+# rule sentieon_filter_DNAscope:
+#     input:
+#         ref = config["reference"]["reference_genome"],
+#         dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
+#     output:
+#         dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
+#     params:
+#         sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+#         sentieon_lic = SENTIEON_LICENSE, 
+#         sentieon_ml_dnascope = SENTIEON_DNASCOPE
+#     threads: 16
+#     log:
+#         vcf_dir + "{sample}.dnascope.filtered.log"
+#     benchmark:
+#         benchmark_dir + "{sample}.dnascope_filter.tsv"
+#     shell:
+#         """
+# export SENTIEON_LICENSE={params.sentieon_lic};
+# export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
-        """
+# {params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
+#         """
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -9,7 +9,7 @@ rule sentieon_DNAscope:
         bam = bam_dir + "{sample}.dedup.realign.bam",
         recal_table = bam_dir + "{sample}.dedup.realign.recal_data.table"
     output:
-        vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz",
+        vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz",
     params:
         sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
         sentieon_lic = SENTIEON_LICENSE, 
@@ -27,23 +27,26 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 		"""
 
 
-#rule sentieon_filter_DNAscope:
-#    input:
-#        ref = config["reference"]["reference_genome"],
-#        dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
-#    output:
-#        dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
-#    params:
-#        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-#        sentieon_lic = SENTIEON_LICENSE, 
-#        sentieon_ml_dnascope = SENTIEON_DNASCOPE
-#    threads: 16
-#    log:
-#        vcf_dir + "{sample}.dnascope.filtered.log"
-#    shell:
-#        """
-#export SENTIEON_LICENSE={params.sentieon_lic};
-#
-#{params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
-#        """
-#
+rule sentieon_filter_DNAscope:
+    input:
+        ref = config["reference"]["reference_genome"],
+        dnascope_vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz"
+    output:
+        dnascope_filtered_vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz"
+    params:
+        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_ml_dnascope = SENTIEON_DNASCOPE
+    threads: 16
+    log:
+        vcf_dir + "{sample}.dnascope.filtered.log"
+    benchmark:
+        vcf_dir + "benchmarks/{sample}.dnascope_filter.tsv"
+    shell:
+        """
+export SENTIEON_LICENSE={params.sentieon_lic};
+export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
+
+{params.sentieon_exec} driver -t {threads} -r {input.ref} --algo DNAModelApply --model {params.sentieon_ml_dnascope} -v {input.dnascope_vcf} {output.dnascope_filtered_vcf}
+        """
+

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -6,7 +6,8 @@ rule sentieon_DNAscope:
     input:
         ref = config["reference"]["reference_genome"],
         dbsnp = config["reference"]["dbsnp"],
-        bam = bam_dir + "{sample}.dedup.bam"
+        bam = bam_dir + "{sample}.dedup.realign.bam",
+        recal_table = bam_dir + "{sample}.dedup.realign.recal_data.table"
     output:
         vcf = vcf_dir + "sentieon_dnascope/SNV.germline.{sample}.dnascope.vcf.gz",
     params:
@@ -20,7 +21,7 @@ rule sentieon_DNAscope:
     	"""
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} --algo DNAscope --pcr_indel_model NONE -d {input.dbsnp} --var_type snp,indel --model {params.sentieon_ml_dnascope} {output.vcf}
+{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal_table} --algo DNAscope -d {input.dbsnp} {output.vcf}
 		"""
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -32,6 +32,8 @@ rule sentieon_TNsnv_tumor_only:
     threads: 16
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnsnv.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -56,6 +58,8 @@ rule sentieon_TNhaplotyper_tumor_only:
     threads: 16
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -71,7 +75,7 @@ rule sentieon_TNscope_tumor_only:
         bam = expand(bam_dir + "{tumor}.dedup.realign.bam", tumor=get_sample_type(config["samples"], "tumor")),
         recal = expand(bam_dir + "{tumor}.dedup.realign.recal_data.table", tumor=get_sample_type(config["samples"], "tumor")),
     output:
-        vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -80,6 +84,8 @@ rule sentieon_TNscope_tumor_only:
     threads: 16
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope_tumor_only.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -88,21 +94,23 @@ export SENTIEON_LICENSE={params.sentieon_lic};
         """
 
 
-rule sentioen_filter_TNscope_tumor_only:
-    input:
-        ref = config["reference"]["reference_genome"],
-        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-    output:
-        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-    params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        sentieon_ml_tnscope = SENTIEON_TNSCOPE
-    log:
-        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
-    shell:
-        """
-export SENTIEON_LICENSE={params.sentieon_lic};
+#rule sentioen_filter_TNscope_tumor_only:
+#    input:
+#        ref = config["reference"]["reference_genome"],
+#        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+#    output:
+#        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+#    params:
+#        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+#        sentieon_lic = SENTIEON_LICENSE, 
+#        sentieon_ml_tnscope = SENTIEON_TNSCOPE
+#    log:
+#        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
+#    shell:
+#        """
+#export SENTIEON_LICENSE={params.sentieon_lic};
+#
+#{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
+#        """
+#
 
-{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
-        """

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -90,7 +90,7 @@ rule sentieon_TNscope_tumor_only:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal} --algo TNscope --tumor_sample {params.tumor} --pon {params.pon} {input.dbsnp} {output.vcf};
+{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal} --algo TNscope --tumor_sample {params.tumor} {params.pon} --dbsnp {input.dbsnp} {output.vcf};
         """
 
 
@@ -106,11 +106,14 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 #        sentieon_ml_tnscope = SENTIEON_TNSCOPE
 #    log:
 #        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
+#    benchmark: 
+#        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope_filter.tsv"
 #    shell:
 #        """
 #export SENTIEON_LICENSE={params.sentieon_lic};
+#export SENTIEON_TNSCOPE={params.sentieon_ml_tnscope};
 #
 #{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
 #        """
-#
+
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -33,7 +33,7 @@ rule sentieon_TNsnv_tumor_only:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnsnv.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnsnv.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -59,7 +59,7 @@ rule sentieon_TNhaplotyper_tumor_only:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -85,7 +85,7 @@ rule sentieon_TNscope_tumor_only:
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope_tumor_only.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnscope.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -22,6 +22,8 @@ rule sentieon_TN_corealign:
     threads: 16
     log:
         vcf_dir + config["analysis"]["case_id"] + ".corealign.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".corealign.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -46,6 +48,8 @@ rule sentieon_TNsnv:
     threads: 16
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnsnv.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -69,6 +73,8 @@ rule sentieon_TNhaplotyper:
     threads: 16
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnhaplotyper.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -86,7 +92,7 @@ rule sentieon_TNscope:
         recalT = expand(bam_dir + "{tumor}.dedup.realign.recal_data.table", tumor=get_sample_type(config["samples"], "tumor")),
         recalN = expand(bam_dir + "{normal}.dedup.realign.recal_data.table", normal=get_sample_type(config["samples"], "normal")),
     output:
-        vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -96,6 +102,8 @@ rule sentieon_TNscope:
     threads: 16
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope.log"
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -104,22 +112,22 @@ export SENTIEON_LICENSE={params.sentieon_lic};
         """
 
 
-rule sentioen_filter_TNscope:
-    input:
-        ref = config["reference"]["reference_genome"],
-        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-    output:
-        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-    params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        sentieon_ml_tnscope = SENTIEON_TNSCOPE
-    log:
-        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
-    shell:
-        """
-export SENTIEON_LICENSE={params.sentieon_lic};
-
-{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
-        """
+#rule sentioen_filter_TNscope:
+#    input:
+#        ref = config["reference"]["reference_genome"],
+#        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+#    output:
+#        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+#    params:
+#        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+#        sentieon_lic = SENTIEON_LICENSE, 
+#        sentieon_ml_tnscope = SENTIEON_TNSCOPE
+#    log:
+#        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
+#    shell:
+#        """
+#export SENTIEON_LICENSE={params.sentieon_lic};
+#
+#{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
+#        """
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -23,7 +23,7 @@ rule sentieon_TN_corealign:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".corealign.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".corealign.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".corealign.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -49,7 +49,7 @@ rule sentieon_TNsnv:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnsnv.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnsnv.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -74,7 +74,7 @@ rule sentieon_TNhaplotyper:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnhaplotyper.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnhaplotyper.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -103,7 +103,7 @@ rule sentieon_TNscope:
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope.log"
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnscope.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
@@ -125,7 +125,7 @@ rule sentioen_filter_TNscope:
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
     benchmark:
-        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope_filter.tsv"
+        benchmark_dir + config["analysis"]["case_id"] + ".tnscope_filter.tsv"
     shell:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -100,7 +100,7 @@ rule sentieon_TNscope:
         """
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver - t {threads} -r {input.ref} -i {input.bamT} {input.recalT} -i {input.bamN} {input.recalN} --algo TNscope --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {params.variant_setting} {output.vcf}
+{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bamT} -q {input.recalT} -i {input.bamN} -q {input.recalN} --algo TNscope --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {params.variant_setting} {output.vcf}
         """
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -92,7 +92,7 @@ rule sentieon_TNscope:
         recalT = expand(bam_dir + "{tumor}.dedup.realign.recal_data.table", tumor=get_sample_type(config["samples"], "tumor")),
         recalN = expand(bam_dir + "{normal}.dedup.realign.recal_data.table", normal=get_sample_type(config["samples"], "normal")),
     output:
-        vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -112,22 +112,25 @@ export SENTIEON_LICENSE={params.sentieon_lic};
         """
 
 
-#rule sentioen_filter_TNscope:
-#    input:
-#        ref = config["reference"]["reference_genome"],
-#        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-#    output:
-#        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-#    params:
-#        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-#        sentieon_lic = SENTIEON_LICENSE, 
-#        sentieon_ml_tnscope = SENTIEON_TNSCOPE
-#    log:
-#        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
-#    shell:
-#        """
-#export SENTIEON_LICENSE={params.sentieon_lic};
-#
-#{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
-#        """
+rule sentioen_filter_TNscope:
+    input:
+        ref = config["reference"]["reference_genome"],
+        tnscope_vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+    output:
+        tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+    params:
+        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
+        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_ml_tnscope = SENTIEON_TNSCOPE
+    log:
+        vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",
+    benchmark:
+        vcf_dir + "benchmarks/" + config["analysis"]["case_id"] + ".tnscope_filter.tsv"
+    shell:
+        """
+export SENTIEON_LICENSE={params.sentieon_lic};
+export SENTIEON_TNSCOPE={params.sentieon_ml_tnscope}
+
+{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply -m {params.sentieon_ml_tnscope} -v {input.tnscope_vcf} {output.tnscope_filtered_vcf}
+        """
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -20,6 +20,8 @@ rule cnvkit_paired:
     name = config["analysis"]["case_id"],
     outdir = cnv_dir,
     conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".cnvkit_paired.tsv"
   shell:
     "source activate {params.conda}; "
     "cnvkit.py target {input.bed} --annotate {input.refflat} --split -o {params.bed}; "

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -20,6 +20,8 @@ rule cnvkit_single:
     name = config["analysis"]["case_id"],
     outdir = cnv_dir,
     conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".cnvkit_single.tsv"
   shell:
     "source activate {params.conda}; "
     "cnvkit.py target {input.bed} --annotate {input.refflat} --split -o {params.bed}; "

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -57,6 +57,8 @@ rule strelka_germline:
         runmode = "local",
         conda = get_conda_env(config["conda_env_yaml"],"strelka"),
     threads: 4
+    benchmark:
+        benchmark_dir + "{sample}.strelka_germline.tsv"
     shell:
         "source activate {params.conda};"
         "rm -rf {params.tmpdir}; "
@@ -84,6 +86,8 @@ rule manta_germline:
         runmode = "local",
         conda = get_conda_env(config["conda_env_yaml"],"manta"),
     threads: 4
+    benchmark:
+        benchmark_dir + "{sample}.manta_germline.tsv"
     shell:
         "source activate {params.conda}; "
         "rm -rf {params.tmpdir}; "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -26,6 +26,8 @@ rule manta_tumor_normal:
 		tmpdir = vcf_dir + "manta/",
 		runmode = "local",
 		conda = get_conda_env(config["conda_env_yaml"],"manta")
+	benchmark: 
+		benchmark_dir + config["analysis"]["case_id"] + ".manta.tsv"
 	threads: 4
 	shell:
 		"source activate {params.conda};"

--- a/BALSAMIC/workflows/Alignment
+++ b/BALSAMIC/workflows/Alignment
@@ -8,6 +8,7 @@ from BALSAMIC.utils.rule import get_result_dir
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+benchmark_dir = config["analysis"]["benchmark"]
 fastq_dir = get_result_dir(config) + "/fastq/"
 bam_dir = get_result_dir(config) + "/bam/"
 cnv_dir = get_result_dir(config) + "/cnv/"

--- a/BALSAMIC/workflows/VariantCalling
+++ b/BALSAMIC/workflows/VariantCalling
@@ -9,6 +9,7 @@ from BALSAMIC.utils.rule import get_vcf
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+benchmark_dir = config["analysis"]["benchmark"]
 fastq_dir = get_result_dir(config) + "/fastq/"
 bam_dir = get_result_dir(config) + "/bam/"
 cnv_dir = get_result_dir(config) + "/cnv/"

--- a/BALSAMIC/workflows/VariantCalling_sentieon
+++ b/BALSAMIC/workflows/VariantCalling_sentieon
@@ -9,11 +9,11 @@ from BALSAMIC.utils.rule import get_vcf
 shell.prefix("set -eo pipefail; ")
 
 rule_dir = config["rule_directory"]
+benchmark_dir = config["analysis"]["benchmark"]
 fastq_dir = get_result_dir(config) + "/fastq/"
 bam_dir = get_result_dir(config) + "/bam/"
 cnv_dir = get_result_dir(config) + "/cnv/"
 cutadapt_dir = get_result_dir(config) + "/cutadapt/"
-fastqc_dir = get_result_dir(config) + "/fastqc/"
 result_dir = get_result_dir(config) + "/"
 vcf_dir = get_result_dir(config) + "/vcf/"
 vep_dir = get_result_dir(config) + "/vep/"
@@ -25,6 +25,7 @@ try:
     SENTIEON_TNSCOPE = os.environ["SENTIEON_TNSCOPE"]
 except Exception as error:
     print("ERROR: Set Environment variable to run this pipeline.")
+    raise
 
 # rules for pipeline
 quality_check = ["snakemake_rules/quality_control/fastp.rule"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ yapf
 graphviz
 coloredlogs
 psutil
-pytest
 snakemake==5.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ pyyaml
 yapf
 graphviz
 coloredlogs
+psutil
+pytest
 snakemake==5.5.1


### PR DESCRIPTION
### This PR:

- TNscope and DNAscope added to sentieon rules
- TNscope filtering based on a machine learning model added
- DNAscope filtering disabled due to machine learning model issues
- Benchmark dir added to capture the processing time and CPU memory usage.
- Fixed fastp rule to write output json and html file for each sample.

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
