### PR TITLE
fix: target bed is not required for wes runs

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -14,7 +14,6 @@ if config["analysis"]["sequencing_type"] == 'wgs':
 else:
     tumor_bam = "tumor.merged.bam"
     cnvkit_params = " --drop-low-coverage --method hybrid "
-    cnvkit_params += f" --targets {cnv_dir}/targets.bed "
 
 rule cnvkit_single:
     input:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Under-the-hood changes that do not have an impact on how end-users run our proce
 increment the patch number. The rational for versioning, and exact wording is taken from BACTpipe: DOI:
 10.5281/zenodo.1254248 and https://github.com/ctmrbio/BACTpipe)
 
+## [x.x.x]
+### Fixed
+- Removed target file from cnvkit batch
+
 ## [3.2.1] - 2019-10-23
 ### Fixed
 - CNVkit single missing reference file added


### PR DESCRIPTION
### This PR:

- Removes `--target` for cnvkit bach. It is redundant with `--reference`

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
