### PR TITLE
SLURM specific details updated for WES analysis

### DIFF
--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -54,7 +54,7 @@
         "n": 16
     },
     "haplotypecaller_merge": {
-        "time": "00:10:00",
+        "time": "00:10:00"
     },
     "strelka_germline": {
         "time": "00:30:00",
@@ -65,7 +65,7 @@
         "n": 16
     },
     "vardict_tumor_only": {
-        "time": "00:30:00",
+        "time": "00:30:00"
     },
     "vardict_merge": {
         "time": "00:10:00"
@@ -76,7 +76,7 @@
     },
     "mutect2_merge": {
         "time": "00:10:00",
-        "n": 16,
+        "n": 16
     },
     "sentieon_align_sort": {
         "time": "24:00:00",

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -12,34 +12,44 @@
         "n": 1
     },
     "RealignerTargetCreator": {
-        "time": "01:00:00"
+        "time": "01:00:00",
+        "n": 16
     },
     "IndelRealigner": {
-        "time": "03:00:00"
+        "time": "03:00:00",
+        "n": 16
     },
     "BaseRecalibrator": {
-        "time": "03:00:00"
+        "time": "03:00:00",
+        "n": 16
     },
     "multiqc": {
-        "time": "00:15:00"
+        "time": "00:15:00",
+        "n": 8
     },
     "MarkDuplicates": {
-        "time": "00:45:00"
+        "time": "00:45:00",
+        "n": 16
     },
     "CollectHsMetrics": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 16
     },
     "CollectAlignmentSummaryMetrics": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 16
     },
     "CollectInsertSizeMetrics": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 16
     },
     "sambamba_panel_depth": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "sambamba_exon_depth": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "bwa_mem": {
         "time": "06:00:00",
@@ -54,7 +64,8 @@
         "n": 16
     },
     "haplotypecaller_merge": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "strelka_germline": {
         "time": "02:00:00",
@@ -65,44 +76,56 @@
         "n": 16
     },
     "vardict_tumor_only": {
-        "time": "02:00:00"
+        "time": "02:00:00",
+        "n": 16
     },
     "vardict_merge": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "mutect2_tumor_only": {
         "time": "06:00:00",
         "n": 16
     },
     "mutect2_merge": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "manta_tumor_only": {
-        "time": "03:00:00"
+        "time": "03:00:00",
+        "n": 16
     },
     "cnvkit_single": {
-        "time": "03:00:00"
+        "time": "03:00:00",
+        "n": 16
     },
     "mergeBam_tumor": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "mergeBam_tumor_gatk": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "mergeBam_normal_gatk": {
-        "time": "00:30:00"  
+        "time": "00:30:00",
+        "n": 8
     },
     "mergeBam_normal": {
-        "time": "00:30:00"
+        "time": "00:30:00",
+        "n": 8
     },
     "cnvkit_paired": {
-        "time": "06:00:00"
+        "time": "06:00:00",
+        "n": 8
     },
     "vardict_tumor_normal": {
-        "time": "05:00:00"
+        "time": "05:00:00",
+        "n": 8
     },
     "vardict_merge": {
-        "time": "00:15:00"
+        "time": "00:15:00",
+        "n": 8
     },
     "mutect2_tumor_normal": {
         "time": "06:00:00",

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -2,7 +2,7 @@
     "__default__": {
         "name": "BALSAMIC.{rule}.{wildcards}",
         "time": "12:00:00",
-        "n": 16,
+        "n": 8,
         "mail_type": "FAIL",
         "partition": "core"
     },
@@ -42,11 +42,11 @@
         "time": "00:30:00"
     },
     "bwa_mem": {
-        "time": "03:00:00",
+        "time": "06:00:00",
         "n": 16
     },
     "samtools_sort_index": {
-        "time": "00:15:00",
+        "time": "00:30:00",
         "n": 16
     },
     "haplotypecaller": {
@@ -54,10 +54,10 @@
         "n": 16
     },
     "haplotypecaller_merge": {
-        "time": "00:10:00"
+        "time": "00:30:00"
     },
     "strelka_germline": {
-        "time": "00:30:00",
+        "time": "02:00:00",
         "n": 16
     },
     "manta_germline": {
@@ -65,18 +65,17 @@
         "n": 16
     },
     "vardict_tumor_only": {
-        "time": "00:30:00"
+        "time": "02:00:00"
     },
     "vardict_merge": {
-        "time": "00:10:00"
+        "time": "00:30:00"
     },
     "mutect2_tumor_only": {
-        "time": "03:00:00",
+        "time": "06:00:00",
         "n": 16
     },
     "mutect2_merge": {
-        "time": "00:10:00",
-        "n": 16
+        "time": "00:30:00"
     },
     "manta_tumor_only": {
         "time": "03:00:00"
@@ -106,7 +105,8 @@
         "time": "00:15:00"
     },
     "mutect2_tumor_normal": {
-        "time": "06:00:00"
+        "time": "06:00:00",
+        "n": 16
     },
     "strelka_tumor_normal": {
         "time": "03:00:00"

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -11,11 +11,72 @@
         "time": "00:15:00",
         "n": 1
     },
-    "vardict_paired": {
-        "time": "24:00:00"
+    "RealignerTargetCreator": {
+        "time": "01:00:00"
     },
-    "mutect2_somatic": {
-        "time": "24:00:00"
+    "IndelRealigner": {
+        "time": "03:00:00"
+    },
+    "BaseRecalibrator": {
+        "time": "03:00:00"
+    },
+    "multiqc": {
+        "time": "00:15:00"
+    },
+    "MarkDuplicates": {
+        "time": "00:45:00"
+    },
+    "CollectHsMetrics": {
+        "time": "00:30:00"
+    },
+    "CollectAlignmentSummaryMetrics": {
+        "time": "00:30:00"
+    },
+    "CollectInsertSizeMetrics": {
+        "time": "00:30:00"
+    },
+    "sambamba_panel_depth": {
+        "time": "00:30:00"
+    },
+    "sambamba_exon_depth": {
+        "time": "00:30:00"
+    },
+    "bwa_mem": {
+        "time": "03:00:00",
+        "n": 16
+    },
+    "samtools_sort_index": {
+        "time": "00:15:00",
+        "n": 16
+    },
+    "haplotypecaller": {
+        "time": "01:00:00",
+        "n": 16
+    },
+    "haplotypecaller_merge": {
+        "time": "00:10:00",
+    },
+    "strelka_germline": {
+        "time": "00:30:00",
+        "n": 16
+    },
+    "manta_germline": {
+        "time": "01:00:00",
+        "n": 16
+    },
+    "vardict_tumor_only": {
+        "time": "00:30:00",
+    },
+    "vardict_merge": {
+        "time": "00:10:00"
+    },
+    "mutect2_tumor_only": {
+        "time": "03:00:00",
+        "n": 16
+    },
+    "mutect2_merge": {
+        "time": "00:10:00",
+        "n": 16,
     },
     "sentieon_align_sort": {
         "time": "24:00:00",

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -78,6 +78,39 @@
         "time": "00:10:00",
         "n": 16
     },
+    "manta_tumor_only": {
+        "time": "03:00:00"
+    },
+    "cnvkit_single": {
+        "time": "03:00:00"
+    },
+    "mergeBam_tumor": {
+        "time": "00:30:00"
+    },
+    "mergeBam_tumor_gatk": {
+        "time": "00:30:00"
+    },
+    "mergeBam_normal_gatk": {
+        "time": "00:30:00"  
+    },
+    "mergeBam_normal": {
+        "time": "00:30:00"
+    },
+    "cnvkit_paired": {
+        "time": "06:00:00"
+    },
+    "vardict_tumor_normal": {
+        "time": "05:00:00"
+    },
+    "vardict_merge": {
+        "time": "00:15:00"
+    },
+    "mutect2_tumor_normal": {
+        "time": "06:00:00"
+    },
+    "strelka_tumor_normal": {
+        "time": "03:00:00"
+    },
     "sentieon_align_sort": {
         "time": "24:00:00",
         "n": 24

--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -109,7 +109,8 @@
         "n": 16
     },
     "strelka_tumor_normal": {
-        "time": "03:00:00"
+        "time": "03:00:00",
+        "n": 16
     },
     "sentieon_align_sort": {
         "time": "24:00:00",

--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -4,6 +4,7 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.utils.rule import get_conda_env
+from BALSAMIC.utils.rule import get_threads
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 rule bwa_mem:
@@ -17,7 +18,7 @@ rule bwa_mem:
   params:
     header_1 = "'@RG\\tID:" +  "{sample}" + "\\tSM:" + "{sample}" + "\\tPL:ILLUMINAi'",
     conda = get_conda_env(config["conda_env_yaml"],"bwa")
-  threads: 4
+  threads: get_threads(cluster_config, "bwa_mem")
   singularity: singularity_image
   benchmark:
     benchmark_dir + "{sample}.bwa_mem.tsv"

--- a/BALSAMIC/snakemake_rules/align/samtools.rule
+++ b/BALSAMIC/snakemake_rules/align/samtools.rule
@@ -4,6 +4,8 @@
 __author__ = "Hassan Foroughi Asl"
 
 from BALSAMIC.utils.rule import get_conda_env
+from BALSAMIC.utils.rule import get_threads
+
 
 rule samtools_sort_index:
   input:
@@ -12,7 +14,7 @@ rule samtools_sort_index:
     bam_dir + "{sample}.sorted.bam"
   params:
     conda = get_conda_env(config["conda_env_yaml"],"samtools") 
-  threads: 4
+  threads: get_threads(cluster_config, "samtools_sort_index")
   singularity: singularity_image 
   benchmark:
     benchmark_dir + '{sample}.samtools_sort.tsv'

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -3,7 +3,8 @@
 
 __author__ = "Hassan Foroughi Asl"
 
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
+from BALSAMIC.utils.rule import get_conda_env
+from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC import __version__ as bv
 
 picarddup = get_picard_mrkdup(config)

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -6,6 +6,7 @@ __author__ = "Hassan Foroughi Asl"
 import os
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_picard_mrkdup
+from BALSAMIC.utils.rule import get_threads
 from BALSAMIC import __version__ as bv
 
 
@@ -22,8 +23,10 @@ rule haplotypecaller:
         vcf_dir + "haplotypecaller/split_vcf/{sample}.{bedchrom}_haplotypecaller.vcf.gz"
     params:
         conda = get_conda_env(config["conda_env_yaml"],"gatk"),
-    threads: 4
+    threads: get_threads(cluster_config, 'haplotypecaller')
     singularity: singularity_image
+    benchmark:
+        benchmark_dir + "haplotypecaller/{sample}.{bedchrom}.haplotypecaller.tsv"
     shell:
         "source activate {params.conda};"
         "gatk3 -T HaplotypeCaller "
@@ -32,6 +35,7 @@ rule haplotypecaller:
             "-L {input.bed} "
             "| bgzip > {output}; " 
         "source deactivate; "
+
 
 rule haplotypecaller_merge:
     input:
@@ -59,7 +63,7 @@ rule strelka_germline:
         tmpdir = vcf_dir + "strelka_germline_{sample}/",
         runmode = "local",
         conda = get_conda_env(config["conda_env_yaml"],"strelka"),
-    threads: 4
+    threads: get_threads(cluster_config, "strelka_germline")
     singularity: singularity_image
     benchmark:
         benchmark_dir + "{sample}.strelka_germline.tsv"
@@ -89,7 +93,7 @@ rule manta_germline:
         tmpdir = vcf_dir + "manta_germline_{sample}/",
         runmode = "local",
         conda = get_conda_env(config["conda_env_yaml"],"manta"),
-    threads: 4
+    threads: get_threads(cluster_config, "manta_germline")
     singularity: singularity_image
     benchmark:
         benchmark_dir + "{sample}.manta_germline.tsv"

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -85,6 +85,6 @@ rule mergeBam_tumor_gatk:
     benchmark_dir + "{mysample}.mergebam_tumor_gatk.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT} OUTPUT={output.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamT} OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
     "source deactivate; "

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -11,71 +11,80 @@ picarddup = get_picard_mrkdup(config)
 
 picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
+normal_sample = get_sample_type(config["samples"], "normal")[0]
+tumor_sample = get_sample_type(config["samples"], "tumor")[0]
 
 rule mergeBam_normal_gatk:
   input:
-    bamN = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "normal")),
+    bamN = bam_dir + "{mysample}.sorted.{picardstr}.ralgn.bsrcl.bam".format(mysample = normal_sample,
+                                                                            picardstr = picarddup)
   output:
     bamN = bam_dir + "normal.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_normal
+    picard = picard_extra_normal
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_normal_gatk.tsv".format(mysample = normal_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamN}.tmp {input.bamN}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamN}.tmp OUTPUT={output.bamN}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamN} OUTPUT={output.bamN}; "
     "samtools index {output.bamN}; "
-    "rm {output.bamN}.tmp; "
     "source deactivate; "
+
 
 rule mergeBam_normal:
   input:
-    bamN = expand(bam_dir + "{mysample}.sorted." + picarddup + ".bam", mysample=get_sample_type(config["samples"], "normal")),
+    bamN = bam_dir + "{mysample}.sorted.{picardstr}.bam".format(mysample = normal_sample,
+                                                                picardstr = picarddup)
   output:
     bamN = bam_dir + "normal.merged.bam", 
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_normal
+    picard = picard_extra_normal
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_normal.tsv".format(mysample = normal_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamN}.tmp {input.bamN}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamN}.tmp OUTPUT={output.bamN}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamN} OUTPUT={output.bamN}; "
     "samtools index {output.bamN}; "
-    "rm {output.bamN}.tmp; "
     "source deactivate; "
+
 
 rule mergeBam_tumor:
   input:
-    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".bam", mysample=get_sample_type(config["samples"], "tumor"))
+    bamT = bam_dir + "{mysample}.sorted.{picardstr}.bam".format(mysample = tumor_sample,
+                                                                picardstr = picarddup)
   output:
     bamT = bam_dir + "tumor.merged.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_tumor
+    picard = picard_extra_tumor
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_tumor.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT}.tmp {input.bamT}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamT} OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
-    "rm {output.bamT}.tmp; "
     "source deactivate; "
+
 
 rule mergeBam_tumor_gatk:
   input:
-    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "tumor"))
+    bamT = bam_dir + "{mysample}.sorted.{picardstr}.ralgn.bsrcl.bam".format(mysample = tumor_sample,
+                                                                            picardstr = picarddup) 
   output:
     bamT = bam_dir + "tumor.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_tumor
+    picard = picard_extra_tumor
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_tumor_gatk.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT}.tmp {input.bamT}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT} OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
-    "rm {output.bamT}.tmp; "
     "source deactivate; "

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-__author__ = "Hassan Foroughi Asl"
-
 from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
 from BALSAMIC import __version__ as bv
@@ -44,6 +42,6 @@ rule mergeBam_tumor_gatk:
     benchmark_dir + "{mysample}.mergebam_tumor_gatk.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamT} OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
     "source deactivate; "

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -8,39 +8,42 @@ from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
 from BALSAMIC import __version__ as bv
 
 picarddup = get_picard_mrkdup(config)
-picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
+tumor_sample = get_sample_type(config["samples"], "tumor")[0]
 
 rule mergeBam_tumor:
   input:
-    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".bam", mysample=get_sample_type(config["samples"], "tumor"))
+    bamT = bam_dir + "{mysample}.sorted.{picardstr}.bam".format(mysample = tumor_sample,
+                                                                picardstr = picarddup) 
   output:
     bamT = bam_dir + "tumor.merged.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_tumor
+    picard = picard_extra_tumor
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_tumor.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT}.tmp {input.bamT}; "
-    "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
+    "picard AddOrReplaceReadGroups {params.picard} INPUT={input.bamT} OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
-    "rm {output.bamT}.tmp; "
     "source deactivate; "
+
 
 rule mergeBam_tumor_gatk:
   input:
-    bamT = expand(bam_dir + "{mysample}.sorted." + picarddup + ".ralgn.bsrcl.bam", mysample=get_sample_type(config["samples"], "tumor"))
+    bamT = bam_dir + "{mysample}.sorted.{picardstr}.ralgn.bsrcl.bam".format(mysample = tumor_sample,
+                                                                            picardstr = picarddup)
   output:
     bamT = bam_dir + "tumor.sorted." + picarddup + ".ralgn.bsrcl.merged.bam",
   params:
     conda = get_conda_env(config["conda_env_yaml"],"picard"),
-    picard=picard_extra_tumor
+    picard = picard_extra_tumor
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "{mysample}.mergebam_tumor_gatk.tsv".format(mysample = tumor_sample)
   shell:
     "source activate {params.conda}; "
-    "samtools merge {output.bamT}.tmp {input.bamT}; "
     "picard AddOrReplaceReadGroups {params.picard} INPUT={output.bamT}.tmp OUTPUT={output.bamT}; "
     "samtools index {output.bamT}; "
-    "rm {output.bamT}.tmp; "
     "source deactivate; "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -5,6 +5,7 @@ import os
 from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_chrom
+from BALSAMIC.utils.rule import get_threads
 from BALSAMIC import __version__ as bv
 
 picarddup = get_picard_mrkdup(config)
@@ -27,6 +28,8 @@ rule vardict_tumor_normal:
     name = config["analysis"]["case_id"],
     conda = get_conda_env(config["conda_env_yaml"], "vardict"),
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "vardict/{bedchrom}.vardict_tumor_normal.tsv"
   shell:
     "source activate {params.conda}; "
     "vardict -G {input.fa} -f {params.af} -N {params.name} "
@@ -47,6 +50,8 @@ rule vardict_merge:
   params:
     conda = get_conda_env(config["conda_env_yaml"], "vardict"),
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".vardict_merge.tsv"
   shell:
     "source activate {params.conda} ; "
     "bcftools concat {input} | bcftools sort - | bgzip > {output}; " 
@@ -66,8 +71,10 @@ rule mutect2_tumor_normal:
   params:
     result_dir = vcf_dir + "mutect/",
     conda = get_conda_env(config["conda_env_yaml"],"gatk")
-  threads: 6
+  threads: get_threads(cluster_config, "mutect2_tumor_normal")
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "mutect2/{bedchrom}.mutect2_tumor_normal.tsv"
   shell:
     "source activate {params.conda};"
     "mkdir -p {params.result_dir}; "
@@ -92,6 +99,8 @@ rule mutect2_merge:
   params:
     conda = get_conda_env(config["conda_env_yaml"],"bcftools"),
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".mutect2_merge.tsv"
   shell:
     "source activate {params.conda} ; "
     "bcftools concat {input} | bcftools sort - | bgzip > {output}; "
@@ -111,8 +120,10 @@ rule strelka_tumor_normal:
     tmpdir = vcf_dir + "strelka/", 
     runmode = "local",
     conda = get_conda_env(config["conda_env_yaml"],"strelka"),
-  threads: 4
+  threads: get_threads(cluster_config, "strelka_tumor_normal")
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".strelka_tumor_normal.tsv"
   shell:
     "source activate {params.conda};"
     "rm -rf {params.tmpdir}; "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -5,6 +5,7 @@ import os
 from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_chrom
+from BALSAMIC.utils.rule import get_threads
 from BALSAMIC import __version__ as bv
 
 picarddup = get_picard_mrkdup(config)
@@ -26,6 +27,8 @@ rule vardict_tumor_only:
     name = config["analysis"]["case_id"],
     conda = get_conda_env(config["conda_env_yaml"],"vardict"),
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + 'vardict/{bedchrom}.vardict.tsv'
   shell:
     "source activate {params.conda}; "
     "vardict -G {input.fa} -f {params.af} -N {params.name} "
@@ -46,6 +49,8 @@ rule vardict_merge:
   params:
     conda = get_conda_env(config["conda_env_yaml"],"vardict"),
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".vardict_merge.tsv"
   shell:
     "source activate {params.conda} ; "
     "bcftools concat {input} | bcftools sort - | bgzip > {output}; "
@@ -64,8 +69,10 @@ rule mutect2_tumor_only:
   params:
     result_dir = vcf_dir + "mutect/",
     conda = get_conda_env(config["conda_env_yaml"],"gatk")
-  threads: 6
+  threads: get_threads(cluster_config, "mutect2_tumor_only")
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + "mutect2/{bedchrom}.mutect2_tumor_only.tsv"
   shell:
     "source activate {params.conda};"
     "mkdir -p {params.result_dir}; "
@@ -87,8 +94,10 @@ rule mutect2_merge:
   output: 
     vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".mutect.vcf.gz"  
   params: 
-    conda = get_conda_env(config["conda_env_yaml"],"bcftools"), 
+    conda = get_conda_env(config["conda_env_yaml"],"bcftools")
   singularity: singularity_image
+  benchmark:
+    benchmark_dir + config["analysis"]["case_id"] + ".mutect2_merge.tsv"
   shell:  
     "source activate {params.conda} ; " 
     "bcftools concat {input} | bcftools sort - | bgzip > {output}; "  


### PR DESCRIPTION
### This PR:

- Updated cluster config file with a time limit and threads for all rules (SLURM)
   - Addressed #229 
- Benchmark added for all variant callers
- Simplified merge bam rules

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
