### PR TITLE
Get sentieon models from assets instead of env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 after_success: coveralls
 
 env:
-  - SENTIEON_LICENSE="/path/to/sentieon_license" SENTIEON_INSTALL_DIR="/path/to/sentieon_install_dir" SENTIEON_DNASCOPE="/path/to/sentieon_dnascope" SENTIEON_TNSCOPE="/path/to/sentieon_dnascope"
+  - SENTIEON_LICENSE="/path/to/sentieon_license" SENTIEON_INSTALL_DIR="/path/to/sentieon_install_dir"
   
 notification:
   - email: false

--- a/BALSAMIC/workflows/VariantCalling_sentieon
+++ b/BALSAMIC/workflows/VariantCalling_sentieon
@@ -25,11 +25,12 @@ singularity_image = config['singularity']['image']
 try:
     SENTIEON_LICENSE = os.environ["SENTIEON_LICENSE"]
     SENTIEON_INSTALL_DIR = os.environ["SENTIEON_INSTALL_DIR"]
-    SENTIEON_DNASCOPE = os.environ["SENTIEON_DNASCOPE"]
-    SENTIEON_TNSCOPE = os.environ["SENTIEON_TNSCOPE"]
 except Exception as error:
     print("ERROR: Set Environment variable to run this pipeline.")
     raise
+
+SENTIEON_DNASCOPE = rule_dir + 'assets/sentieon_models/SentieonDNAscopeModelBeta0.4a-201808.05.model'
+SENTIEON_TNSCOPE = rule_dir + 'assets/sentieon_models/SentieonTNscopeModel_GiAB_HighAF_LowFP-201711.05.model'
 
 # rules for pipeline
 quality_check = ["snakemake_rules/quality_control/fastp.rule", \


### PR DESCRIPTION
### This PR:

- Fix: #246 Variant calling WGS will get sentieon models from assets dir instead of environment variables.

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
