### PR TITLE
Added qsub modifications to scheduler.py, added PERL5LIB to vep.rule,…

### DIFF
--- a/BALSAMIC/commands/run/scheduler.py
+++ b/BALSAMIC/commands/run/scheduler.py
@@ -113,12 +113,13 @@ class QsubScheduler:
         if self.dependency:
             for jobid in self.dependency:
                 depend = depend + ":" + jobid
-            qsub_options.append(" -W \"depend=afterok" + str(depend) + "\"")
+            #qsub_options.append(" -W \"depend=afterok" + str(depend) + "\"")
+            qsub_options.append(" -hold_jid " + ",".join(self.dependency))
 
         if self.script:
             qsub_options.append(" {} ".format(self.script))
 
-        return "qsub -S /bin/bash " + " ".join(qsub_options)
+        return "qsub -V -S /bin/bash " + " ".join(qsub_options)
 
 
 def read_sample_config(input_json):
@@ -167,7 +168,8 @@ def submit_job(sbatch_cmd, profile):
         m = re.search("Submitted batch job (\d+)", res)
         jobid = m.group(1)
     elif profile == "qsub":
-        jobid = str(res)
+        jobid_tmp = str(res).split()[3]
+        jobid = jobid_tmp.strip("\"()\"")
 
     print(jobid)
     return jobid

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -27,6 +27,7 @@ rule vep:
   shell:
     "source activate {params.conda}; "
     "vep_path=$(dirname $(readlink -e $(which vep))); "
+    "export PERL5LIB=;"
     "vep "
         "--dir $vep_path "
         "--dir_cache {params.vep_cache} "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -33,6 +33,7 @@ rule vardict_tumor_normal:
     benchmark_dir + 'vardict_tumor_normal_' + "{bedchrom}.vardict_tumor_normal.tsv"
   shell:
     "source activate {params.conda}; "
+    "export PERL5LIB=;"
     "vardict -G {input.fa} -f {params.af} -N {params.name} "
         "-b \"{input.bamT}|{input.bamN}\" "
         "{params.col_info} {input.bed} "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -40,6 +40,7 @@ rule vardict_tumor_only:
     benchmark_dir + 'vardict_tumor_only_' + '{bedchrom}.vardict.tsv'
   shell:
     "source activate {params.conda}; "
+    "export PERL5LIB=;"
     "vardict -G {input.fa} -f {params.af} -N {params.name} "
         "-b {input.bamT} "
         "{params.col_info} {input.bed} "


### PR DESCRIPTION
… somatic_tumor_normal.rule somatic_tumor_only.rule

### This PR:

- Added qsub modifications to scheduler.py
- added PERL5LIB to vep.rule, somatic_tumor_normal.rule, somatic_tumor_only.rule

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
