### PR TITLE
Qsub test update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 ### Changed
 - Increased time for indel realigner and base recalib rules
 - decoupled vep stat from vep main rule
-- changed qsub command. removed time and account for qsub.
+- changed qsub command to match UGE
 
 ### Fixed
 - WGS qc rules - updated with correct options


### PR DESCRIPTION
### This PR:

- This PR fixes broken tests for new qsub case for #260 

Qsub:
- returns `Your job 501107 ("qsub_test.sh") has been submitted` as output.
- require -hold_jobid instead of afterok for building dependency trees.
- Addition of `-V` with following explanation from documentation (http://gridscheduler.sourceforge.net/htmlman/htmlman1/qsub.html):
```
     -V   Available for qsub, qsh, qrsh with command and qalter.

          Specifies that all environment variables active  within
          the qsub utility be exported to the context of the job.
```

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
