### PR TITLE
Added reference genome to be able to calculate AT/CG dropouts

### DIFF
--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -46,6 +46,7 @@ rule CollectHsMetrics:
     fadict = (config["reference"]["reference_genome"]).replace(".fasta",".dict"),
     bed = config["panel"]["capture_kit"],
     bam = bam_dir + "{sample}.sorted." + picarddup + ".bam",
+    fa = config["reference"]["reference_genome"],
   output:
     mrkdup = bam_dir + "{sample}.sorted." + picarddup + ".hsmetric"
   params:
@@ -67,6 +68,7 @@ rule CollectHsMetrics:
       "TI={input.bam}.picard.bedintervals "
       "I={input.bam} "
       "O={output.mrkdup} "
+      "R={input.fa} "
       "COVERAGE_CAP=50000 "
       "METRIC_ACCUMULATION_LEVEL=ALL_READS; "
     "source deactivate; "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 ### Added
 - VEP now also produces a tab delimited file
 - CNVkit rules output genemetrics and gene break file
+- Added reference genome to be able to calculate AT/CG dropouts by Picard
 
 ### Changed
 - Increased time for indel realigner and base recalib rules


### PR DESCRIPTION
### This PR:

Added reference genome to be able to calculate AT/CG dropouts.

### How to test:

Run e.g. sample ACC5831A5 and compare the AT/CG dropout with the values provided by Twist.

### Expected outcome:
A value from picard for the AT/CG dropout.

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
