### PR TITLE
refactor scout config generation

### DIFF
--- a/BALSAMIC/assets/scout_config_template.yaml
+++ b/BALSAMIC/assets/scout_config_template.yaml
@@ -2,34 +2,35 @@
 
 owner: cust000
 
-family: 'cancer_test'
-family_name: 'cancer'
+family: 'lovingtiger'
+family_name: 'lovingtiger'
 samples:
   - analysis_type: panel
-    sample_id: 999-99
-    tumor_type: Chordoma
-    capture_kit: Twist.V1
-    sample_name: 999-99
+    sample_id: tumor
+    tumor_type: unknown 
+    capture_kit: capture_kit_name
+    sample_name: tumor
     phenotype: affected
-    sex: male
-    expected_coverage: 90
-    mt_bam: scout/demo/reduced_mt.bam
-    tmb: 7
-    msi: 15
-    tumor_purity: 90/90
+    sex: unknown 
+    expected_coverage: unknown 
+    tmb: unknown 
+    msi: unknown
+    tumor_purity: unknown 
+    bam_path: path_tumor_merged.bam 
 
   - analysis_type: panel
-    sample_id: 998-99
-    capture_kit: Twist.V1
-    sample_name: 998-99
+    sample_id: normal
+    capture_kit: capture_kit_name 
+    sample_name: normal
     phenotype: unaffected
-    sex: male
-    expected_coverage: 90
-    mt_bam: scout/demo/reduced_mt.bam
+    sex: unknown 
+    expected_coverage: unknown 
+    bam_path: path_tumor_merged.bam 
 
-vcf_cancer: scout/demo/cancer_test.vcf.gz
+vcf_cancer: path_to_final_vcf 
+vcf_cancer_sv: path_to_final_vcf 
 
-delivery_report: scout/demo/delivery_report.html
+multiqc: path_multiqc_report 
 
 default_gene_panels: [panel1]
 gene_panels: [panel1]
@@ -37,6 +38,6 @@ gene_panels: [panel1]
 # meta data
 rank_model_version: '1.1'
 rank_score_threshold: -100
-analysis_date: 2018-10-12 14:00:46
+analysis_date: 'N/A' 
 human_genome_build: 37
 track: cancer

--- a/BALSAMIC/commands/plugins/scout.py
+++ b/BALSAMIC/commands/plugins/scout.py
@@ -5,6 +5,8 @@ import json
 import yaml
 import click
 import shutil
+import sys
+import datetime
 
 from BALSAMIC.utils.rule import get_result_dir
 
@@ -15,8 +17,13 @@ LOG = logging.getLogger(__name__)
 @click.option("--sample-config",
               required=True,
               help="Sample config file. Output of balsamic config sample")
+@click.option("--snv-vcf", default="vcfmerge", help="variant caller to load as vcf_cancer") 
+@click.option("--tumor", default="TUMOR", help="sample name for tumor sample")
+@click.option("--normal", default="NORMAL", help="sample name for normal sample")
+@click.option("--sv-vcf", default="manta", help="variant caller to load as vcf_cancer_sv") 
+@click.option("--customer-id", required=True, help="customer id for scout config")
 @click.pass_context
-def scout(context, sample_config):
+def scout(context, sample_config, snv_vcf, sv_vcf, customer_id, tumor, normal):
     '''
     Create a scout config.yaml file
     '''
@@ -25,6 +32,8 @@ def scout(context, sample_config):
 
     with open(sample_config, 'r') as fn:
         sample_config = json.load(fn)
+    case_name=sample_config['analysis']['case_id']
+    capture_kit=os.path.basename(sample_config['panel']['capture_kit'])
 
     result_dir = get_result_dir(sample_config)
     dst_directory = os.path.join(result_dir, 'scout')
@@ -34,10 +43,49 @@ def scout(context, sample_config):
 
     scout_config_src = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                     "../../assets/scout_config_template.yaml")
+    with open(scout_config_src, 'r') as fn:
+        scout_config = yaml.load(fn, Loader=yaml.SafeLoader)
+
+    deliver_wildcards = {
+        'bam': {'tumor': 'tumor.merged.bam', 'normal': 'normal.merged.bam'},
+        'vep': {'vcf_cancer_sv': f'SV.somatic.{case_name}.{sv_vcf}.vcf.gz',
+                'vcf_cancer': f'SNV.somatic.{case_name}.{snv_vcf}.vcf.gz'},
+        'qc': 'multiqc_report.html'
+    }
+
+    if sample_config['analysis']['analysis_type'] == 'single':
+        del deliver_wildcards['bam']['normal']
+        scout_config['samples'].pop(1)
+
+    scout_config['owner'] = customer_id
+    scout_config['family'] = case_name
+    scout_config['family_name'] = case_name
+
+    scout_config['analysis_date'] = str(datetime.datetime.now())
+
+    #scout_config['vcf_cancer_sv'] = os.path.join(result_dir, 'vep', deliver_wildcards['vep']['vcf_cancer_sv'])
+    scout_config.pop('vcf_cancer_sv')
+    scout_config['vcf_cancer'] = os.path.join(result_dir, 'vep', deliver_wildcards['vep']['vcf_cancer'])
+
+    scout_config['multiqc'] = os.path.join(result_dir, 'qc', deliver_wildcards['qc'])
+
+    # scout sample info for tumor
+    scout_config['samples'][0]['bam_path'] = os.path.join(result_dir, 'bam', deliver_wildcards['bam']['tumor'])
+    scout_config['samples'][0]['capture_kit'] = capture_kit
+    scout_config['samples'][0]['sample_id'] = tumor
+    scout_config['samples'][0]['sample_name'] = tumor
+
+    if sample_config['analysis']['analysis_type'] == 'paired':
+        scout_config['samples'][1]['bam_path'] = os.path.join(result_dir, 'bam', deliver_wildcards['bam']['normal'])
+        scout_config['samples'][1]['capture_kit'] = capture_kit
+        scout_config['samples'][1]['sample_id'] = normal
+        scout_config['samples'][1]['sample_name'] = normal
+
     scout_config_dst = os.path.join(
         dst_directory, sample_config['analysis']['case_id'] + ".scout.yaml")
 
     LOG.debug('Creating scout config %s', scout_config_dst)
-    shutil.copyfile(scout_config_src, scout_config_dst)
+    with open(scout_config_dst, 'w') as f:
+        yaml.dump(scout_config, f, default_flow_style=False)
     LOG.info('Scout config template is successfully created: %s',
              scout_config_dst)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 - Increased time for indel realigner and base recalib rules
 - decoupled vep stat from vep main rule
 - changed qsub command to match UGE
+- scout plugin updated
 
 ### Fixed
 - WGS qc rules - updated with correct options

--- a/tests/commands/plugins/test_scout.py
+++ b/tests/commands/plugins/test_scout.py
@@ -3,10 +3,20 @@ import pytest
 import BALSAMIC
 from BALSAMIC.commands.base import cli
 
-def test_scout(invoke_cli, tumor_normal_config):
+def test_scout_tumor_normal(invoke_cli, tumor_normal_config):
     # GIVEN a tumor-normal config file
     # WHEN running analysis
-    result = invoke_cli(['plugins', 'scout', '--sample-config', tumor_normal_config])
+    result = invoke_cli(['plugins', 'scout', '--sample-config', tumor_normal_config, '--customer-id', 'cust000'])
 
     # THEN it should run without any error
+    print(result)
+    assert result.exit_code == 0
+
+def test_scout_tumor_only(invoke_cli, tumor_only_config):
+    # GIVEN a tumor-only config file
+    # WHEN running analysis
+    result = invoke_cli(['plugins', 'scout', '--sample-config', tumor_only_config, '--customer-id', 'cust000'])
+
+    # THEN it should run without any error
+    print(result)
     assert result.exit_code == 0


### PR DESCRIPTION
### This PR:

- scout plugin for balsamic is a bit more verbose. This was used to create config for following cases: https://github.com/Clinical-Genomics/Cancer-project/issues/37

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
