### PR TITLE
Release 4.1.0

### DIFF
--- a/BALSAMIC/config/cluster_minimal.json
+++ b/BALSAMIC/config/cluster_minimal.json
@@ -1,8 +1,8 @@
 {
     "__default__": {
         "name": "BALSAMIC.{rule}.{wildcards}",
-        "time": "01:00:00",
-        "n": 8,
+        "time": "00:45:00",
+        "n": 6,
         "mail_type": "FAIL",
         "partition": "core"
     },

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -11,30 +11,33 @@ fasta = config["reference"]["reference_genome"]
 refflat = config["reference"]["refflat"]
 
 if config["analysis"]["sequencing_type"] == 'wgs':
-    normal_bam = "{normal}.dedup.realign.bam".format(normal = get_sample_type(config["samples"], "normal")[0])
-    tumor_bam = "{tumor}.dedup.realign.bam".format(tumor = get_sample_type(config["samples"], "tumor")[0])
+    normal_bam = "{normal}.dedup.realign".format(normal = get_sample_type(config["samples"], "normal")[0])
+    tumor_bam = "{tumor}.dedup.realign".format(tumor = get_sample_type(config["samples"], "tumor")[0])
     cnvkit_params = " --method wgs "
     cnvkit_params += " --target-avg-size 1000 "
     cnvkit_params += f" -f {fasta} --annotate {refflat} "
     
 else:
-    normal_bam = "normal.merged.bam"
-    tumor_bam = "tumor.merged.bam"
+    normal_bam = "normal.merged"
+    tumor_bam = "tumor.merged"
     cnvkit_params = " --drop-low-coverage --method hybrid "
     cnvkit_params += f" --targets {cnv_dir}/targets.bed "
+    cnvkit_params += " --target-avg-size 50 "
 
 rule cnvkit_paired:
     input:
         fasta = fasta, 
         refflat = refflat, 
-        bamN = bam_dir + normal_bam, 
-        bamT = bam_dir + tumor_bam, 
+        bamN = bam_dir + normal_bam + ".bam", 
+        bamT = bam_dir + tumor_bam + ".bam"
     output:
         done = cnv_dir + "cnvkit_paired.done"
     params:
         extra = cnvkit_params,
         target = config["panel"]["capture_kit"] if "panel" in config else "None", 
         name = config["analysis"]["case_id"],
+        normal_name = normal_bam,
+        tumor_name = tumor_bam,
         cnv_dir = cnv_dir,
         conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
     singularity: singularity_image
@@ -42,16 +45,18 @@ rule cnvkit_paired:
         benchmark_dir + "cnvkit_paired_" + config["analysis"]["case_id"] + ".cnvkit_paired.tsv"
     shell:
         "source activate {params.conda}; "
-        "[ {params.target} != None ] && cnvkit.py target {params.target} --annotate {input.refflat} --split -o {params.cnv_dir}/targets.bed; "
+        "if [ {params.target} != None ]; then "
+        "cnvkit.py target {params.target} --annotate {input.refflat} --split -o {params.cnv_dir}/targets.bed; "
+        "fi; "
         "cnvkit.py batch {input.bamT} "
             "--normal {input.bamN} " 
             "{params.extra} "
             "--output-reference {params.cnv_dir}/Reference.cnn "
             "--scatter --diagram "
             "--output-dir {params.cnv_dir} && touch {output.done}; "
-        "cnvkit.py genemetrics {params.cnv_dir}/tumor.merged.cnr "
-            "-s {params.cnv_dir}/tumor.merged.cns "
-            "-t 0.585 -m 10 --drop-low-coverage -y "
+        "cnvkit.py genemetrics {params.cnv_dir}/{params.tumor_name}.cnr "
+            "-s {params.cnv_dir}/{params.tumor_name}.cns "
+            "--drop-low-coverage -y "
             "--output {params.cnv_dir}/{params.name}.gene_metrics.csv; "
-        "cnvkit.py breaks {params.cnv_dir}/tumor.merged.cnr {params.cnv_dir}/tumor.merged.cns "
+        "cnvkit.py breaks {params.cnv_dir}/{params.tumor_name}.cnr {params.cnv_dir}/{params.tumor_name}.cns "
             "| cut -f1 | sort -u > {params.cnv_dir}/{params.name}.gene_breaks.csv; "

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -6,21 +6,21 @@ from BALSAMIC import __version__ as bv
 
 fasta = config["reference"]["reference_genome"]
 refflat = config["reference"]["refflat"]
+wgs_calling_interval = config["reference"]["wgs_calling_interval"]
 
 if config["analysis"]["sequencing_type"] == 'wgs':
-    tumor_bam = "{tumor}.dedup.realign.bam".format(tumor = get_sample_type(config["samples"], "tumor")[0])
+    tumor_bam = "{tumor}.dedup.realign".format(tumor = get_sample_type(config["samples"], "tumor")[0])
     cnvkit_params = " --method wgs "
-    cnvkit_params += " --target-avg-size 1000 "
-    cnvkit_params += f" -f {fasta} --annotate {refflat} "
 else:
-    tumor_bam = "tumor.merged.bam"
+    tumor_bam = "tumor.merged"
     cnvkit_params = " --drop-low-coverage --method hybrid "
 
 rule cnvkit_single:
     input:
         fasta = fasta, 
         refflat = refflat, 
-        bamT = bam_dir + tumor_bam, 
+        wgs_calling_interval = wgs_calling_interval, 
+        bamT = bam_dir + tumor_bam + ".bam", 
     output:
         done = cnv_dir + "cnvkit_single.done"
     params:
@@ -28,6 +28,7 @@ rule cnvkit_single:
         refcnn = cnv_dir + "FlatReference.cnn",
         target = config["panel"]["capture_kit"] if "panel" in config else "None", 
         name = config["analysis"]["case_id"],
+        tumor_name = tumor_bam,
         cnv_dir = cnv_dir,
         conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
     singularity: singularity_image
@@ -35,16 +36,20 @@ rule cnvkit_single:
         benchmark_dir + 'cnvkit_single_' + config["analysis"]["case_id"] + ".cnvkit_single.tsv"
     shell:
         "source activate {params.conda}; "
-        "[ {params.target} != None ] && cnvkit.py target {params.target} --annotate {input.refflat} --split -o {params.cnv_dir}/targets.bed; "
-        "[ {params.target} != None ] && cnvkit.py reference -o {params.refcnn} -f {input.fasta} -t {params.cnv_dir}/targets.bed; "
-        "[ {params.target} != None ] && ref_param='--reference {params.refcnn}' ; " 
+        "if [ {params.target} != None ]; then "
+        "cnvkit.py target {params.target} --annotate {input.refflat} --split -o {params.cnv_dir}/targets.bed; "
+        "cnvkit.py reference -o {params.refcnn} -f {input.fasta} -t {params.cnv_dir}/targets.bed; "
+        "else "
+        "cnvkit.py reference -o {params.refcnn} -f {input.fasta} -t {input.wgs_calling_interval}; " 
+        "fi; "
         "cnvkit.py batch {input.bamT} "
-            "{params.extra} ${{ref_param}} "
+            "{params.extra} "
+            " --reference {params.refcnn} "
             " --scatter --diagram "
             " --output-dir {params.cnv_dir} && touch {output.done}; "
-        "cnvkit.py genemetrics {params.cnv_dir}/tumor.merged.cnr "
-            "-s {params.cnv_dir}/tumor.merged.cns "
-            "-t 0.585 -m 10 --drop-low-coverage -y "
+        "cnvkit.py genemetrics {params.cnv_dir}/{params.tumor_name}.cnr "
+            "-s {params.cnv_dir}/{params.tumor_name}.cns "
+            "--drop-low-coverage -y "
             "--output {params.cnv_dir}/{params.name}.gene_metrics.csv; "
-        "cnvkit.py breaks {params.cnv_dir}/tumor.merged.cnr {params.cnv_dir}/tumor.merged.cns "
+        "cnvkit.py breaks {params.cnv_dir}/{params.tumor_name}.cnr {params.cnv_dir}/{params.tumor_name}.cns "
             "| cut -f1 | sort -u > {params.cnv_dir}/{params.name}.gene_breaks.csv; "

--- a/BALSAMIC/workflows/GenerateRef
+++ b/BALSAMIC/workflows/GenerateRef
@@ -23,6 +23,7 @@ vcf_1kg_url = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.wgs
 cosmicdb_url = "https://cancer.sanger.ac.uk/cosmic/file_download/GRCh37/cosmic/v90/VCF/CosmicCodingMuts.vcf.gz"
 refgene_txt_url = "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refGene.txt.gz"
 refgene_sql_url = "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refGene.sql"
+wgs_calling_url = "gs://gatk-legacy-bundles/b37/wgs_calling_regions.v1.interval_list"
 
 # VCF files list for wildcards
 VCF = ['dbsnp_grch37_b138.vcf', '1k_genome_wgs_p1_v3_all_sites.vcf',
@@ -42,6 +43,7 @@ reference_genome_index = os.path.join(genome_dir, "human_g1k_v37_decoy.fasta.fai
 refseq_bed = os.path.join(genome_dir, "refseq.flat.bed")
 refgene = os.path.join(genome_dir, "refGene.txt")
 refseq_flat = os.path.join(genome_dir, "refseq.flat")
+wgs_calling_interval =  os.path.join(genome_dir, "wgs_calling_regions.v1")
 genome_dict = os.path.join(genome_dir, "human_g1k_v37_decoy.dict")
 
 dbsnp = os.path.join(vcf_dir, "dbsnp_grch37_b138.vcf")
@@ -53,12 +55,14 @@ cosmicdb = os.path.join(vcf_dir, "cosmic_coding_muts_v89.vcf")
 check_md5 = os.path.join(basedir, "reference_" + str(current_day) + ".md5")
 
 # list of reference download link and output file name
-ref_list = [(reference_genome_url, reference_genome, "gsutil"),
-            (dbsnp_url, dbsnp, "gsutil"),
-            (hc_vcf_1kg_url, hc_vcf_1kg, "gsutil"),
-            (mills_1kg_url, mills_1kg, "gsutil"),
-            (known_indel_1kg_url, known_indel_1kg, "gsutil"),
-            (vcf_1kg_url, vcf_1kg, "wget")]
+ref_list_gzip = [(reference_genome_url, reference_genome, "gsutil"),
+                (dbsnp_url, dbsnp, "gsutil"),
+                (hc_vcf_1kg_url, hc_vcf_1kg, "gsutil"),
+                (mills_1kg_url, mills_1kg, "gsutil"),
+                (known_indel_1kg_url, known_indel_1kg, "gsutil"),
+                (vcf_1kg_url, vcf_1kg, "wget")]
+
+ref_list_flat = [(wgs_calling_url, wgs_calling_interval, "gsutil"),] 
 
 shell.prefix("set -eo pipefail; ")
 
@@ -103,7 +107,8 @@ rule all:
         known_indel_1kg = known_indel_1kg + ".gz",
         cosmic_vcf = cosmicdb + ".gz",
         variants_idx = expand( vcf_dir + "{vcf}.gz.tbi", vcf=VCF),
-        vep = vep_dir
+        vep = vep_dir,
+        wgs_calling = wgs_calling_interval
     output:
         finished = os.path.join(basedir,"reference.finished"),
         reference_json = reference_json,
@@ -125,6 +130,7 @@ rule all:
             "exon_bed": input.refseq_bed,
             "refflat": input.refseq_flat,
             "refGene": input.refgene,
+            "wgs_calling_interval": input.wgs_calling,
             "vep": input.vep
         }
 
@@ -142,16 +148,19 @@ rule all:
 ##########################################################
 
 rule download_reference:
-    params:
-        link = ref_list
     output:
-        expand("{output}", output=[ref[1] for ref in ref_list])
+        expand("{output}", output=[ref[1] for ref in ref_list_gzip + ref_list_flat])
     run:
-        for ref in ref_list:
+        for ref in ref_list_gzip:
             if ref[2] == "gsutil":
                 shell("gsutil cp -L {ref[1]}.log {ref[0]} - | gunzip > {ref[1]}") 
             else:
                 shell("wget -a {ref[1]}.log -O - {ref[0]} | gunzip > {ref[1]}")
+        for ref in ref_list_flat:
+            if ref[2] == "gsutil":
+                shell("gsutil cp -L {ref[1]}.log {ref[0]} {ref[1]}") 
+            else:
+                shell("wget -a {ref[1]}.log -O {ref[1]} {ref[0]}")
 
 rule download_refgene:
     params:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 - CNVkit rules output genemetrics and gene break file
 - Added reference genome to be able to calculate AT/CG dropouts by Picard
 - coverage plot plugin part of issue #75
+- callable regions for CNV calling of tumor-only
 
 ### Changed
 - Increased time for indel realigner and base recalib rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Under-the-hood changes that do not have an impact on how end-users run our proce
 increment the patch number. The rational for versioning, and exact wording is taken from BACTpipe: DOI:
 10.5281/zenodo.1254248 and https://github.com/ctmrbio/BACTpipe)
 
-## [x.x.x]
+## [4.1.0]
 ### Added
 - VEP now also produces a tab delimited file
 - CNVkit rules output genemetrics and gene break file

--- a/tests/test_data/references/reference.json
+++ b/tests/test_data/references/reference.json
@@ -10,6 +10,7 @@
         "vep": "tests/test_data/references/vep/",
         "refflat": "tests/test_data/references/genome/refseq.flat",
         "refGene": "tests/test_data/references/genome/refGene.txt",
+        "wgs_calling_interval": "tests/test_data/references/genome/wgs_calling_regions.v1",
         "exon_bed": "tests/test_data/references/genome/refseq.flat.bed"
     }
 }


### PR DESCRIPTION
### This PR:

## [4.1.0]
### Added
- VEP now also produces a tab delimited file
- CNVkit rules output genemetrics and gene break file
- Added reference genome to be able to calculate AT/CG dropouts by Picard
- coverage plot plugin part of issue #75

### Changed
- Increased time for indel realigner and base recalib rules
- decoupled vep stat from vep main rule
- changed qsub command to match UGE
- scout plugin updated

### Fixed
- WGS qc rules - updated with correct options
  (picard - CollectMultipleMetrics, sentieon - CoverageMetrics)
- Log warning if WES workflow cannot find SENTIEON* env variables
- Fixes issue with cnvkit and WGS samples #268
- Fix #267 coverage issue with long deletions in vardict

### How to test:

These workflows should finish without error:
- [x] Tumor-Normal targeted seq
- [x] Tumor-only targeted seq
- [x] Tumor-Normal whole genome
- [x] Tumor-only whole exome
- [x] Reference download

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
