### PR TITLE
Vep refactor

### DIFF
--- a/BALSAMIC/conda/BALSAMIC-py36.yaml
+++ b/BALSAMIC/conda/BALSAMIC-py36.yaml
@@ -15,7 +15,7 @@ dependencies:
   - gatk=3.8
   - picard=2.17.0
   - vardict=2019.06.04=pl526_0
-  - ensembl-vep=94.5
+  - ensembl-vep=99.1
   - cnvkit=0.9.4a0
   - multiqc=1.7 
   - bedtools=2.28.0

--- a/BALSAMIC/containers/Dockerfile.latest
+++ b/BALSAMIC/containers/Dockerfile.latest
@@ -12,7 +12,7 @@ RUN mkdir -p /git_repos; \
     export PATH=/usr/local/miniconda/bin:$PATH; \
     export LC_ALL=en_US.utf-8; \
     export LANG=en_US.utf-8; \
-    cd /git_repos && git clone https://github.com/Clinical-Genomics/BALSAMIC && cd BALSAMIC && git checkout vep_refactor; \
+    cd /git_repos && git clone https://github.com/Clinical-Genomics/BALSAMIC && cd BALSAMIC && git checkout vep_refactor master; \
     conda env create --file BALSAMIC/conda/BALSAMIC-py27.yaml -n BALSAMIC_py27 \
     && conda env create --file BALSAMIC/conda/BALSAMIC-py36.yaml -n BALSAMIC_py36 \
     source activate BALSAMIC_py36; \

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -7,24 +7,21 @@
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_threads
 
-rule vep:
+rule vep_somatic:
   input:
-    vcf = vcf_dir + "{type}.{mutation}.{sample}.{caller}.vcf.gz",
+    vcf = vcf_dir + "{type}.somatic.{sample}.{caller}.vcf.gz",
+    header = vcf_dir + "{type}.somatic.{sample}.{caller}.sample_name_map",
     cosmic = config["reference"]["cosmic"]
   output:
-    tab = vep_dir + "{type}.{mutation}.{sample}.{caller}.tsv",
-    vcf = vep_dir + "{type}.{mutation}.{sample}.{caller}.vcf.gz",
-    vcf_pass = vep_dir + "{type}.{mutation}.{sample}.{caller}.pass.vcf.gz",
+    vcf = vep_dir + "{type}.somatic.{sample}.{caller}.vcf.gz",
+    vcf_pass = vep_dir + "{type}.somatic.{sample}.{caller}.pass.vcf.gz",
   params:
-    bed = config["panel"]["capture_kit"] if "panel" in config else "",
     conda = get_conda_env(config["conda_env_yaml"],"ensembl-vep"),
-    filter_vep_string = "'not COSMIC and not Existing_variation'", 
-    bcftools_filter_string = "INFO/DP>=50 && FORMAT/AD>=5 && FORMAT/AF>=0.1",
     vep_cache = config["reference"]["vep"]
   threads: get_threads(cluster_config, 'vep')
   singularity: singularity_image 
   benchmark:
-    benchmark_dir + 'vep_' + "{type}.{mutation}.{sample}.{caller}.vep.tsv"
+    benchmark_dir + 'vep_' + "{type}.somatic.{sample}.{caller}.vep.tsv"
   shell:
     "source activate {params.conda}; "
     "vep_path=$(dirname $(readlink -e $(which vep))); "
@@ -34,27 +31,14 @@ rule vep:
         "--dir_cache {params.vep_cache} "
         "--dir_plugins $vep_path "
         "--input_file {input.vcf} "
-        "--output_file STDOUT "
+        "--output_file {output.vcf} "
+        "--compress_output bgzip "
         "--fork {threads} "
         "--vcf "
         "--everything "
-        "--format vcf "
-        "--offline "
-        "--variant_class "
-        "--merged "
-        "--cache "
-        "--custom {input.cosmic},COSMIC,vcf,exact,0,CDS,GENE,STRAND,CNT,AA "
-        "--verbose "
-        "--force_overwrite | bgzip > {output.vcf} && tabix -f -p vcf {output.vcf};"
-    "bcftools view -f .,PASS {input.vcf} --output-file {output.vcf_pass} --output-type z;"
-    "bcftools view -f .,PASS {input.vcf} | vep "
-        "--dir $vep_path "
-        "--dir_cache {params.vep_cache} "
-        "--dir_plugins $vep_path "
-        "--output_file {output.tab} "
-        "--fork {threads} "
-        "--tab "
-        "--everything "
+        "--allow_non_variant "
+        "--dont_skip "
+        "--buffer_size 10000 "
         "--format vcf "
         "--offline "
         "--variant_class "
@@ -63,9 +47,9 @@ rule vep:
         "--custom {input.cosmic},COSMIC,vcf,exact,0,CDS,GENE,STRAND,CNT,AA "
         "--verbose "
         "--force_overwrite; "
-    "tabix -p vcf --force {output.vcf}; "
-    "tabix -p vcf --force {output.vcf_pass}; "
- 
+    "tabix -p vcf -f {output.vcf}; "
+    "bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf}; "
+    "tabix -p vcf -f {output.vcf_pass}; " 
     
 
 rule vep_stat:

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -54,9 +54,9 @@ rule vep_somatic:
 
 rule vep_stat:
   input:
-    vep = vep_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".vcfmerge.vcf.gz",
+    vep = vep_dir + "SNV.somatic.{sample}.{caller}.pass.vcf.gz",
   output:
-    stat = vep_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".vcfmerge.balsamic_stat"
+    stat = vep_dir + "SNV.somatic.{sample}.{caller}.pass.balsamic_stat"
   params:
     bed = config["panel"]["capture_kit"] if "panel" in config else "",
     conda = get_conda_env(config["conda_env_yaml"],"ensembl-vep"),
@@ -65,11 +65,11 @@ rule vep_stat:
   threads: get_threads(cluster_config, 'vep')
   singularity: singularity_image 
   benchmark:
-    benchmark_dir + 'vep_stat_' + "SNV.somatic." + config["analysis"]["case_id"] + ".vcfmerge.balsamic_stat.tsv" 
+    benchmark_dir + "vep_stat_SNV.somatic.{sample}.{caller}.pass.balsamic_stat.tsv" 
   shell:
     "source activate {params.conda}; "
     "if [ \"{params.bed}\" == \"\" ]; then region_size=3101.78817; else region_size=$(awk '{{s+=$3-$2}}END{{print s/1e6}}' {params.bed}); fi; "
-    "bcftools view -f PASS {input.vep} 2> /dev/null "
+    "bcftools view --type snps -f PASS {input.vep} 2> /dev/null "
         " | bcftools filter -i \"{params.bcftools_filter_string}\" "
         " | filter_vep --ontology --filter {params.filter_vep_string} "
         " | bcftools +counts "

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -25,7 +25,7 @@ rule sentieon_TNsnv_tumor_only:
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
         stats = vcf_dir + config["analysis"]["case_id"] + ".tnsnv.call_stats",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -42,7 +42,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -q {input.recal_data_table} -i {input.bam} --algo TNsnv --tumor_sample {params.tumor} {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} --call_stats_out {output.stats} {output.vcf} 
 
-"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; 
         """
 
 rule sentieon_TNhaplotyper_tumor_only:
@@ -54,7 +54,7 @@ rule sentieon_TNhaplotyper_tumor_only:
         cosmic = config["reference"]["cosmic"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -71,7 +71,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} -q {input.recal_data_table} --algo TNhaplotyper --tumor_sample {params.tumor} {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} {output.vcf} 
 
-"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; 
         """
 
 
@@ -83,7 +83,7 @@ rule sentieon_TNscope_tumor_only:
         recal = expand(bam_dir + "{tumor}.dedup.realign.recal_data.table", tumor=get_sample_type(config["samples"], "tumor")),
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsope.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -100,7 +100,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal} --algo TNscope --tumor_sample {params.tumor} {params.pon} --dbsnp {input.dbsnp} {output.vcf};
 
-"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; 
         """
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -25,6 +25,7 @@ rule sentieon_TNsnv_tumor_only:
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
         stats = vcf_dir + config["analysis"]["case_id"] + ".tnsnv.call_stats",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -40,6 +41,8 @@ rule sentieon_TNsnv_tumor_only:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -q {input.recal_data_table} -i {input.bam} --algo TNsnv --tumor_sample {params.tumor} {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} --call_stats_out {output.stats} {output.vcf} 
+
+"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
         """
 
 rule sentieon_TNhaplotyper_tumor_only:
@@ -51,6 +54,7 @@ rule sentieon_TNhaplotyper_tumor_only:
         cosmic = config["reference"]["cosmic"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -66,6 +70,8 @@ rule sentieon_TNhaplotyper_tumor_only:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} -q {input.recal_data_table} --algo TNhaplotyper --tumor_sample {params.tumor} {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} {output.vcf} 
+
+"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
         """
 
 
@@ -77,6 +83,7 @@ rule sentieon_TNscope_tumor_only:
         recal = expand(bam_dir + "{tumor}.dedup.realign.recal_data.table", tumor=get_sample_type(config["samples"], "tumor")),
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsope.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -92,6 +99,8 @@ rule sentieon_TNscope_tumor_only:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal} --algo TNscope --tumor_sample {params.tumor} {params.pon} --dbsnp {input.dbsnp} {output.vcf};
+
+"echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; " 
         """
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -43,7 +43,7 @@ rule sentieon_TNsnv:
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
         stats = vcf_dir + config["analysis"]["case_id"] + ".tnsnv.call_stats",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -60,7 +60,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --algo TNsnv --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} --call_stats_out {output.stats} {output.vcf} 
 
-"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap};
         """
 
 
@@ -71,7 +71,7 @@ rule sentieon_TNhaplotyper:
         dbsnp = config["reference"]["dbsnp"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -88,7 +88,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --algo TNhaplotyper --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {output.vcf}
 
-"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap};
         """
 
 
@@ -102,7 +102,7 @@ rule sentieon_TNscope:
         recalN = expand(bam_dir + "{normal}.dedup.realign.recal_data.table", normal=get_sample_type(config["samples"], "normal")),
     output:
         vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -120,7 +120,7 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bamT} -q {input.recalT} -i {input.bamN} -q {input.recalN} --algo TNscope --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {params.variant_setting} {output.vcf}
 
-"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
+echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap};
         """
 
 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -31,6 +31,7 @@ rule sentieon_TN_corealign:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bamT} -i {input.bamN} -q {input.recalT} -q {input.recalN} --algo Realigner -k {input.mills} -k {input.indel_1kg} {output.bam}
+
         """
 
 
@@ -42,6 +43,7 @@ rule sentieon_TNsnv:
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
         stats = vcf_dir + config["analysis"]["case_id"] + ".tnsnv.call_stats",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnsnv.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -57,6 +59,8 @@ rule sentieon_TNsnv:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --algo TNsnv --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} --call_stats_out {output.stats} {output.vcf} 
+
+"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
         """
 
 
@@ -67,6 +71,7 @@ rule sentieon_TNhaplotyper:
         dbsnp = config["reference"]["dbsnp"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -82,6 +87,8 @@ rule sentieon_TNhaplotyper:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --algo TNhaplotyper --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {output.vcf}
+
+"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
         """
 
 
@@ -95,6 +102,7 @@ rule sentieon_TNscope:
         recalN = expand(bam_dir + "{normal}.dedup.realign.recal_data.table", normal=get_sample_type(config["samples"], "normal")),
     output:
         vcf = vcf_dir + "sentieon_tnscope/SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -111,6 +119,8 @@ rule sentieon_TNscope:
 export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bamT} -q {input.recalT} -i {input.bamN} -q {input.recalN} --algo TNscope --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {params.variant_setting} {output.vcf}
+
+"echo -e \"{params.tumor}\\tTUMOR\n{params.normal}\\tNORMAL\" > {output.namemap}; " 
         """
 
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -31,7 +31,8 @@ rule cnvkit_paired:
         bamN = bam_dir + normal_bam + ".bam", 
         bamT = bam_dir + tumor_bam + ".bam"
     output:
-        vcf = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz"
+        vcf = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz",
+        namemap = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.sample_name_map"
     params:
         extra = cnvkit_params,
         target = config["panel"]["capture_kit"] if "panel" in config else "None", 
@@ -66,3 +67,4 @@ rule cnvkit_paired:
         "tabix -p vcf {params.cnv_dir}/{params.tumor_name}.vcf.gz; "
         "bcftools sort -o {output.vcf} -O z {params.cnv_dir}/{params.tumor_name}.vcf.gz; " 
         "tabix -p vcf {output.vcf}; "
+        "echo -e \"TUMOR\\tTUMOR\" > {output.namemap}; " 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -22,7 +22,8 @@ rule cnvkit_single:
         wgs_calling_interval = wgs_calling_interval, 
         bamT = bam_dir + tumor_bam + ".bam", 
     output:
-        vcf = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz"
+        vcf = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz",
+        namemap = vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.sample_name_map"
     params:
         extra = cnvkit_params,
         refcnn = cnv_dir + "FlatReference.cnn",
@@ -54,8 +55,9 @@ rule cnvkit_single:
         "cnvkit.py breaks {params.cnv_dir}/{params.tumor_name}.cnr {params.cnv_dir}/{params.tumor_name}.cns "
             "| cut -f1 | sort -u > {params.cnv_dir}/{params.name}.gene_breaks.csv; "
         "cnvkit.py export vcf {params.cnv_dir}/{params.tumor_name}.cns --cnr {params.cnv_dir}/{params.tumor_name}.cnr "
-            "-o {params.cnv_dir}/{params.tumor_name}.vcf --sample-id TUMOR;"
+            "-o {params.cnv_dir}/{params.tumor_name}.vcf --sample-id TUMOR; "
         "bgzip {params.cnv_dir}/{params.tumor_name}.vcf; "
         "tabix -p vcf {params.cnv_dir}/{params.tumor_name}.vcf.gz; "
         "bcftools sort -o {output.vcf} -O z {params.cnv_dir}/{params.tumor_name}.vcf.gz; " 
         "tabix -p vcf {output.vcf}; "
+        "echo -e \"TUMOR\\tTUMOR\" > {output.namemap}; " 

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -51,7 +51,6 @@ rule haplotypecaller_merge:
         "source activate {params.conda}; "
         "bcftools concat {input} | bcftools sort - | bgzip > {output}; "
         "tabix -f -p vcf {output}; "
-        "source deactivate;"
 
 
 rule strelka_germline:

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -23,6 +23,7 @@ rule manta_tumor_normal:
     output:
         candidateindel = vcf_dir + "manta/results/variants/candidateSmallIndels.vcf.gz",
         final = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".manta.vcf.gz",
+        namemap = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".manta.sample_name_map",
     params:
         tmpdir = vcf_dir + "manta/",
         runmode = "local",
@@ -42,4 +43,5 @@ rule manta_tumor_normal:
         "python {params.tmpdir}/runWorkflow.py -m {params.runmode} -j {threads};"
         "cp {params.tmpdir}/results/variants/somaticSV.vcf.gz {output.final}; "
         "tabix -p vcf -f {output.final}; "
+        "echo -e \"TUMOR\\tTUMOR\nNORMAL\\tNORMAL\" > {output.namemap}; " 
         

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
@@ -18,6 +18,7 @@ rule manta_tumor_only:
     output:
       candidateindel = vcf_dir + "manta/results/variants/candidateSmallIndels.vcf.gz",
       final = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".manta.vcf.gz",
+      namemap = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".manta.sample_name_map"
     params:
       tmpdir = vcf_dir + "manta/",
       runmode = "local",
@@ -36,4 +37,5 @@ rule manta_tumor_only:
       "python {params.tmpdir}/runWorkflow.py -m {params.runmode} -j {threads};"
       "cp {params.tmpdir}/results/variants/tumorSV.vcf.gz {output.final}; "
       "tabix -p vcf -f {output.final}; "
+      "echo -e \"TUMOR\\tTUMOR\" > {output.namemap}; " 
       

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -34,7 +34,7 @@ rule vardict_tumor_normal:
   shell:
     "source activate {params.conda}; "
     "export PERL5LIB=;"
-    "vardict -u -I 600 -G {input.fa} -f {params.af} -N {params.name} "
+    "vardict -U -u -I 600 -G {input.fa} -f {params.af} -N {params.name} "
         "-b \"{input.bamT}|{input.bamN}\" "
         "{params.col_info} {input.bed} "
         "| testsomatic.R "

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -208,6 +208,7 @@ rule sentieon_TNhaplotyper:
         dbsnp = config["reference"]["dbsnp"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
@@ -224,4 +225,5 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bamT} -i {input.bamN} --interval {input.interval} --algo TNhaplotyper --tumor_sample TUMOR --normal_sample NORMAL --dbsnp {input.dbsnp} {output.vcf}
         
+echo -e \"TUMOR\\tTUMOR\nNORMAL\\tNORMAL\" > {output.namemap}; 
         """

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -170,6 +170,7 @@ rule sentieon_TNhaplotyper_tumor_only:
         interval = config["panel"]["capture_kit"],
     output:
         vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnhaplotyper.sample_name_map",
     params:
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
@@ -186,4 +187,5 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 {params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --interval {input.interval} --algo TNhaplotyper --tumor_sample TUMOR {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} {output.vcf} 
 
+echo -e \"TUMOR\\tTUMOR\" > {output.namemap};
         """

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -41,7 +41,7 @@ rule vardict_tumor_only:
   shell:
     "source activate {params.conda}; "
     "export PERL5LIB=;"
-    "vardict -u -I 600 -G {input.fa} -f {params.af} -N {params.name} "
+    "vardict -U -u -I 600 -G {input.fa} -f {params.af} -N {params.name} "
         "-b {input.bamT} "
         "{params.col_info} {input.bed} "
         "| teststrandbias.R "

--- a/BALSAMIC/workflows/VariantCalling
+++ b/BALSAMIC/workflows/VariantCalling
@@ -114,8 +114,7 @@ rule all:
     input:
         os.path.join(*([result_dir + "qc/" + "multiqc_report.html"])),
         expand(vep_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, somatic_caller, [config["analysis"]["case_id"]])),
-        expand(vep_dir + "{vcf}.vcf.gz", vcf=get_vcf(config, germline_caller, config["samples"])),
-        vep_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".vcfmerge.balsamic_stat"
+        expand(vep_dir + "{vcf}.pass.balsamic_stat", vcf=get_vcf(config, somatic_caller_snv + sentieon_callers, [config["analysis"]["case_id"]])),
     output:
         os.path.join(get_result_dir(config), "analysis_finish")
     shell:

--- a/BALSAMIC/workflows/VariantCalling_sentieon
+++ b/BALSAMIC/workflows/VariantCalling_sentieon
@@ -73,7 +73,7 @@ rule all:
         expand(bam_dir + "{sample}.dedup.realign.recal.csv", sample=config["samples"]),
         expand(bam_dir + "{sample}.dedup.realign.recal.pdf", sample=config["samples"]),
         expand(vep_dir + "{vcf}.vcf.gz", vcf = get_vcf(config, somatic_caller, [config["analysis"]["case_id"]])),
-        expand(vep_dir + "{vcf}.vcf.gz", vcf = get_vcf(config, germline_caller, config["samples"])),
+        expand(vcf_dir + "{vcf}.vcf.gz", vcf = get_vcf(config, germline_caller, config["samples"])),
         expand(qc_dir + "{sample}_sentieon_wgs_metrics.txt", sample=config["samples"]),
         expand(qc_dir + "{sample}_coverage", sample=config["samples"]),
         expand(qc_dir + "multiqc_report.html"),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ increment the patch number. The rational for versioning, and exact wording is ta
 ### Fixed
 - remove source deactivate from rules to suppress conda warning
 
+### Removed
+- Removed annotation for germline caller results 
+
 ## [4.1.0]
 ### Added
 - VEP now also produces a tab delimited file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 - bed files are slopped 100bp for variant calling fix #262
 - disable vcfmerge
 - Picard markduplicate output moved from log to output
+- vep upgraded to 99.1
 
 ### Fixed
 - remove source deactivate from rules to suppress conda warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ increment the patch number. The rational for versioning, and exact wording is ta
 - disable vcfmerge
 - Picard markduplicate output moved from log to output
 - vep upgraded to 99.1
+- removed SVs from vardict
 
 ### Fixed
 - remove source deactivate from rules to suppress conda warning


### PR DESCRIPTION
### This PR:

- refactor's vep rule
- adds namemaps to variant callers
- removes SV from vardict
- removes germline annotation
- removes tsv from vep's output

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
