### PR TITLE
Set TMPDIR for splitbed rule

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -26,6 +26,7 @@ rule split_bed_by_chrom:
     singularity: singularity_image
     shell:
         "source activate {params.conda}; "
+        "export TMPDIR={params.split_bed_dir}; "
         "chromlist=`cut -f 1 {input.bed} | sort -u`; "
         "sed 's/^chr//g;/_/d' {input.chrom} | sort -k1,1 > {params.split_bed_dir}hg19.chrom.sizes; "
         "for c in $chromlist; "


### PR DESCRIPTION
### This PR:
- Fixes an issue with `sort` that looks for `$TMPDIR`

### How to test:
- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
