### PR TITLE
refactor, update container and add a cli option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changed
 
 * Variant caller filters moved into pydantic
 * Install script and setup.py
+* refactored install script with more log output and added a conda env suffix option
 
 
 [4.3.0]

--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,12 @@ _yellow=${_log}'\033[1;33m';
 _nocol='\033[0m';
 _condaprefix=D
 
-while getopts ":s:p:v:ch" opt; do
+while getopts ":s:v:b:e:p:ch" opt; do
   case $opt in
     s) sFlag=true;_condaprefix=${OPTARG};;
     v) vFlag=true;_balsamic_ver=${OPTARG};;
+    b) bFlag=true;_balsamic_branch=${OPTARG};;
+    e) eFlag=true;_envsuffix=${OPTARG};;
     p) pFlag=true;_condapath=${OPTARG};;
     c) cFlag=true;;
     h)
@@ -21,9 +23,10 @@ USAGE: $0 [-s _condaprefix -v _balsamic_ver -p _condapath -c]
   1. Conda naming convention: [P,D,S]_[ENVNAME]_%DATE. P: Production, D: Development, S: Stage
   2. Conda environment prefix: Path to conda env. e.g. /home/user/conda_env/
   
-  -s _condaprefix     Conda env name prefix. This will be P or D in the help above. 
-  -v _balsamic_ver    Balsamic version tag to install 
-  -p _condapath       Conda env path prefix. See point 2 in help above.
+  -s _condaprefix     Conda env name prefix. This will be P or D in the help above
+  -v _balsamic_ver    Balsamic version tag to install (4.0.0+), or it could be the branch name
+  -e _envsuffix       Balsamic conda env suffix. This will be added to the conda env name
+  -p _condapath       Conda env path prefix. See point 2 in help above
   -c                  If set it will use Singularity container for conda instead 
 " >&2
       exit 0
@@ -45,17 +48,24 @@ then
   exit 1
 fi
 
-if [[ ! -z $vFlag ]]
+if [[ -z $_balsamic_ver ]]
 then
-  _envsuffix=_${_balsamic_ver}
+  echo -e "\n${_yellow}WARNING: No version or branch is set, master branch will be used.${_nocol}"
+  _balsamic_ver="master"
+fi
+
+if [[ -z $_envsuffix ]]
+then
+  echo -e "\n${_yellow}WARNING: No conda env suffix provdided.${_nocol}"
 fi
 
 # Check if container flag is specified
 if [[ $cFlag ]]
 then
-  if [[ -f ${PWD}'/BALSAMIC/containers/BALSAMIC_miniconda3_4_6_14.sif' ]];
+  current_conda_sif=${PWD}'/BALSAMIC/containers/BALSAMIC_miniconda3_4_6_14.sif'
+  if [[ -f ${current_conda_sif} ]];
   then
-    echo -e "\n${_green}Container for miniconda3 4.6.14 exists.${_nocol}"
+    echo -e "\n${_green}Container for miniconda3 4.6.14 exists: ${current_conda_sif} ${_nocol}"
   else
     echo -e "\n${_green}Pulling a miniconda3 4.6.14 from shub://Clinical-Genomics/BALSAMIC:miniconda3_4_6_14.${_nocol}"
     singularity pull ${PWD}'/BALSAMIC/containers/BALSAMIC_miniconda3_4_6_14.sif' docker://hassanf/miniconda3_4.6.14 
@@ -75,33 +85,35 @@ then
     }
 fi
 
-_env_name=${_condaprefix}_BALSAMIC-base${_envsuffix}
+# Create conda environment
+_env_name=${_condaprefix}_BALSAMIC${_envsuffix}
 _balsamic_envs=${PWD}'/BALSAMIC_env.yaml'
 _balsamic_ruledir=${PWD}'/BALSAMIC/'
 
 echo -e "${_green}Creating conda env ${_env_name}${_nocol}"
-conda env create -f BALSAMIC/conda/BALSAMIC-base.yaml --quiet --prefix ${_condapath}/${_env_name} --force
+conda env create --file BALSAMIC/conda/BALSAMIC-base.yaml --quiet --prefix ${_condapath}/${_env_name} --force
 
 echo -e "${_green}Activating ${_env_name}${_nocol}"
-echo $_env_name
 source activate ${_env_name}
 
+echo -e "${_green}Installing BALSAMIC from origin.${_nocol}"
+echo pip install -U git+https://github.com/Clinical-Genomics/BALSAMIC@${_balsamic_ver}
+
+# Pull Docker container
 if [[ ${_balsamic_ver} =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
 then
-  echo -e "${_green}Pulling version $vFlag of container.${_nocol}"
+  echo -e "${_green}Pulling version ${_balsamic_ver} of container.${_nocol}"
   container_version=release_v${_balsamic_ver} 
-  git_version=${_balsamic_ver}
 else
   echo -e "${_green}Pulling latest version of container.${_nocol}"
   container_version=latest
-  git_version=master
 fi
-  
-echo -e "${_green}Installing BALSAMIC${_nocol}"
-pip install -U git+https://github.com/Clinical-Genomics/BALSAMIC@${_balsamic_ver}
 
-echo -e "${_green}Grabbing container${_nocol}"
-singularity pull --force ${PWD}"/BALSAMIC/containers/BALSAMIC_${container_version}.sif" docker://hassanf/balsamic:${container_version}
+
+_container_path=${PWD}"/BALSAMIC/containers/BALSAMIC_${container_version}.sif"
+_docker_path=docker://hassanf/balsamic:${container_version}
+echo -e "${_green}Grabbing container: ${_container_path} ${_nocol}"
+echo singularity pull --force ${_container_path} ${_docker_path}
 
 echo -e "\n${_green}Install finished. To start working with BALSAMIC, run: source activate ${_env_name}.${_nocol}"
 

--- a/install.sh
+++ b/install.sh
@@ -9,11 +9,10 @@ _yellow=${_log}'\033[1;33m';
 _nocol='\033[0m';
 _condaprefix=D
 
-while getopts ":s:v:b:e:p:ch" opt; do
+while getopts ":s:v:e:p:ch" opt; do
   case $opt in
     s) sFlag=true;_condaprefix=${OPTARG};;
     v) vFlag=true;_balsamic_ver=${OPTARG};;
-    b) bFlag=true;_balsamic_branch=${OPTARG};;
     e) eFlag=true;_envsuffix=${OPTARG};;
     p) pFlag=true;_condapath=${OPTARG};;
     c) cFlag=true;;
@@ -97,7 +96,7 @@ echo -e "${_green}Activating ${_env_name}${_nocol}"
 source activate ${_env_name}
 
 echo -e "${_green}Installing BALSAMIC from origin.${_nocol}"
-echo pip install -U git+https://github.com/Clinical-Genomics/BALSAMIC@${_balsamic_ver}
+pip install -U git+https://github.com/Clinical-Genomics/BALSAMIC@${_balsamic_ver}
 
 # Pull Docker container
 if [[ ${_balsamic_ver} =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
@@ -113,7 +112,7 @@ fi
 _container_path=${PWD}"/BALSAMIC/containers/BALSAMIC_${container_version}.sif"
 _docker_path=docker://hassanf/balsamic:${container_version}
 echo -e "${_green}Grabbing container: ${_container_path} ${_nocol}"
-echo singularity pull --force ${_container_path} ${_docker_path}
+singularity pull --force ${_container_path} ${_docker_path}
 
 echo -e "\n${_green}Install finished. To start working with BALSAMIC, run: source activate ${_env_name}.${_nocol}"
 


### PR DESCRIPTION
### This PR:

Refactors install script.

1. Adds support for conda env suffix
1. Updates script log output is more verbose, and outputs conda env name, container names, etc.
1. Cleans up path values and assigns them to a variable that can be reused.

### How to test:

- Automatic and continuous test pass
- Install BALSAMIC via install script and check that it is working for:
1. release version
1. a specific branch
1. master

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
