### PR TITLE
Add normal sample to run_validate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ install:
 
 script:
   - py.test --cov=BALSAMIC -rsxv tests/* 
-  - mkdir -p reference/GRCh37 && cp tests/test_data/references/reference.json reference/GRCh37/reference.json
-  - ./run_validate.sh -a T -m all -t panel
-  - ./run_validate.sh -a TN -m all -t panel
-  - ./run_validate.sh -a T -m all -t WGS
-  - ./run_validate.sh -a TN -m all -t WGS
 
 after_success: coveralls
 

--- a/run_validate.sh
+++ b/run_validate.sh
@@ -70,10 +70,16 @@ if [[ ! -z ${rFlag} ]]; then
   _run_analysis="-r"
 fi
 
+if [[ ${_analysis} == "TN" ]]; then
+  _normal_option="-n ${_normal_fastq}"
+else
+  _normal_option=" "
+fi
+
 function balsamic_config() {
   balsamic config case \
     -t ${_tumor_fastq} \
-    -n ${_normal_fastq} \
+    ${_normal_option} \
     --case-id ${_analysis}_${_ngstype} \
     --analysis-dir ${_analysis_dir} \
     -r ${_reference} \


### PR DESCRIPTION
### This PR:

- Adds normal sample to run_validate script
- Removes run_validate from .travis.yaml

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
