### PR TITLE
Fix/revert cnvkit 0.9.4

### DIFF
--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -7,5 +7,4 @@ dependencies:
   - python=3.6
   - bcftools
   - tabix
-  - samtools
   - cnvkit=0.9.4a0

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -8,4 +8,3 @@ dependencies:
   - tabix
   - samtools
   - cnvkit=0.9.4a0
-  - libiconv

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,11 +1,13 @@
 channels:
   - bioconda
   - defaults
+  - r
 
 dependencies:
   - python=3.6
   - pip=9.0.3
   - bcftools
   - tabix
+  - r-base=3.6.1
   - pip:
     - cnvkit==0.9.7

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -8,4 +8,4 @@ dependencies:
   - bcftools
   - tabix
   - pip:
-    - cnvkit=0.9.7
+    - cnvkit==0.9.7

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,7 +1,7 @@
 channels:
+  - conda-forge
   - bioconda
   - defaults
-  - conda-forge
 
 dependencies:
   - bcftools

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
   - defaults
   - r
 

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -7,10 +7,10 @@ channels:
 dependencies:
   - python=3.6
   - pip=9.0.3
-  - bcftools
-  - tabix
+  - bcftools=1.10.2
+  - tabix=0.2.6
   - r-base=3.6.1
-  - bioconductor-dnacopy
+  - bioconductor-dnacopy=1.60.0
   - pip:
       - cnvkit==0.9.4
       - biopython==1.76

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -4,6 +4,7 @@ channels:
   - defaults
 
 dependencies:
+  - python=3.6
   - bcftools
   - tabix
   - samtools

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,11 +1,19 @@
 channels:
   - bioconda
-  - conda-forge
   - defaults
 
 dependencies:
   - python=3.6
-  - biopython>=1.76
+  - pip=9.0.3
   - bcftools
   - tabix
-  - cnvkit=0.9.6
+  - cnvkit=0.9.4a0
+  - numpy
+  - scipy
+  - pandas
+  - matplotlib
+  - reportlab
+  - biopython
+  - pyfaidx
+  - pysam
+  - pyvcf

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+  - defaults
+  - conda-forge
+
+dependencies:
+  - bcftools
+  - tabix
+  - samtools
+  - cnvkit=0.9.4a0
+  - libiconv

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -9,5 +9,4 @@ dependencies:
   - bcftools
   - tabix
   - r-base=3.6.1
-  - pip:
-    - cnvkit==0.9.7
+  - cnvkit=0.9.7

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -1,10 +1,11 @@
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
   - defaults
 
 dependencies:
   - python=3.6
+  - biopython>=1.76
   - bcftools
   - tabix
-  - cnvkit=0.9.4a0
+  - cnvkit=0.9.6

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -7,13 +7,5 @@ dependencies:
   - pip=9.0.3
   - bcftools
   - tabix
-  - cnvkit=0.9.4a0
-  - numpy
-  - scipy
-  - pandas
-  - matplotlib
-  - reportlab
-  - biopython
-  - pyfaidx
-  - pysam
-  - pyvcf
+  - pip:
+    - cnvkit=0.9.7

--- a/BALSAMIC/conda/varcall_cnvkit.yaml
+++ b/BALSAMIC/conda/varcall_cnvkit.yaml
@@ -10,4 +10,7 @@ dependencies:
   - bcftools
   - tabix
   - r-base=3.6.1
-  - cnvkit=0.9.7
+  - bioconductor-dnacopy
+  - pip:
+      - cnvkit==0.9.4
+      - biopython==1.76

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -1,6 +1,6 @@
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
   - defaults
 
 dependencies:
@@ -8,5 +8,5 @@ dependencies:
   - strelka=2.8.4
   - manta=1.3.0
   - bcftools>=1.10
-  - tabix=0.2.6
+  - tabix>=0.2.5
   - samtools>=1.9

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -9,4 +9,4 @@ dependencies:
   - manta=1.3.0
   - bcftools>=1.10
   - tabix=0.2.6
-  - samtools=1.9.0
+  - samtools>=1.9

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -7,6 +7,6 @@ dependencies:
   - python=2.7
   - strelka=2.8.4
   - manta=1.3.0
-  - bcftools=1.10.2
+  - bcftools>=1.10
   - tabix=0.2.6
   - samtools=1.9.0

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -7,6 +7,6 @@ dependencies:
   - python=2.7
   - strelka=2.8.4
   - manta=1.3.0
-  - bcftools>=1.10
+  - bcftools>=1.9
   - tabix>=0.2.5
   - samtools>=1.9

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -7,6 +7,6 @@ dependencies:
   - python=2.7
   - strelka=2.8.4
   - manta=1.3.0
-  - bcftools>=1.9
-  - tabix>=0.2.5
-  - samtools>=1.6
+  - bcftools=1.10.2
+  - tabix=0.2.6
+  - samtools=1.9.0

--- a/BALSAMIC/conda/varcall_py27.yaml
+++ b/BALSAMIC/conda/varcall_py27.yaml
@@ -9,4 +9,4 @@ dependencies:
   - manta=1.3.0
   - bcftools>=1.9
   - tabix>=0.2.5
-  - samtools>=1.9
+  - samtools>=1.6

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -9,5 +9,5 @@ dependencies:
   - gatk=3.8
   - samtools=1.10
   - vardict=2019.06.04=pl526_0
-  - cnvkit=0.9.7
+  - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -7,7 +7,6 @@ dependencies:
   - python=3.6
   - bcftools=1.9
   - tabix=0.2.5
-  - gatk=3.8
   - samtools=1.6
   - vardict=2019.06.04=pl526_0
   - cnvkit=0.9.4a0

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -4,10 +4,11 @@ channels:
   - defaults
 
 dependencies:
-  - bcftools
-  - tabix
+  - python=3.6
+  - bcftools=1.9
+  - tabix=0.2.5
   - gatk=3.8
-  - samtools
+  - samtools=1.6
   - vardict=2019.06.04=pl526_0
-  - cnvkit
+  - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - bcftools=1.10.2
+  - bcftools>=1.10
   - tabix=0.2.6
   - gatk=3.8
   - samtools=1.10

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -5,9 +5,9 @@ channels:
 
 dependencies:
   - python=3.6
-  - bcftools=1.9
-  - tabix=0.2.5
-  - samtools=1.6
+  - bcftools=1.10.2
+  - tabix=0.2.6
+  - samtools=1.10
   - gatk=3.8
   - vardict=2019.06.04=pl526_0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -7,7 +7,7 @@ dependencies:
   - bcftools>=1.10
   - tabix=0.2.6
   - gatk=3.8
-  - samtools=1.10
+  - samtools>=1.9
   - vardict=2019.06.04=pl526_0
   - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 
 dependencies:
-  - bcftools>=1.10
+  - bcftools>=1.9
   - tabix>=0.2.5
   - gatk=3.8
   - samtools>=1.9

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -8,6 +8,6 @@ dependencies:
   - bcftools=1.9
   - tabix=0.2.5
   - samtools=1.6
+  - gatk=3.8
   - vardict=2019.06.04=pl526_0
-  - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -9,5 +9,5 @@ dependencies:
   - gatk=3.8
   - samtools
   - vardict=2019.06.04=pl526_0
-  - cnvkit=0.9.4a0
+  - cnvkit
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -4,10 +4,10 @@ channels:
   - defaults
 
 dependencies:
-  - bcftools>=1.9
-  - tabix>=0.2.5
+  - bcftools
+  - tabix
   - gatk=3.8
-  - samtools>=1.6
+  - samtools
   - vardict=2019.06.04=pl526_0
   - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -1,11 +1,11 @@
 channels:
   - bioconda
-  - defaults
   - conda-forge
+  - defaults
 
 dependencies:
   - bcftools>=1.10
-  - tabix=0.2.6
+  - tabix>=0.2.5
   - gatk=3.8
   - samtools>=1.9
   - vardict=2019.06.04=pl526_0

--- a/BALSAMIC/conda/varcall_py36.yaml
+++ b/BALSAMIC/conda/varcall_py36.yaml
@@ -7,7 +7,7 @@ dependencies:
   - bcftools>=1.9
   - tabix>=0.2.5
   - gatk=3.8
-  - samtools>=1.9
+  - samtools>=1.6
   - vardict=2019.06.04=pl526_0
   - cnvkit=0.9.4a0
   - libiconv

--- a/BALSAMIC/config/balsamic_env.yaml
+++ b/BALSAMIC/config/balsamic_env.yaml
@@ -17,10 +17,11 @@ varcall_py36:
   - tabix
   - gatk
   - vardict
-  - cnvkit
   - libiconv
 varcall_py27:
   - strelka
   - manta
+varcall_cnvkit:
+  - cnvkit
 vcf_merge:
   - vcfmerge

--- a/BALSAMIC/containers/Dockerfile.latest
+++ b/BALSAMIC/containers/Dockerfile.latest
@@ -15,6 +15,7 @@ RUN mkdir -p /git_repos; \
     export LANG=en_US.utf-8; \
     conda clean -iy; \
     cd /git_repos && git clone https://github.com/Clinical-Genomics/BALSAMIC && cd BALSAMIC && git checkout ${GIT_BRANCH} && \
+    conda env create --file BALSAMIC/conda/varcall_cnvkit.yaml -n varcall_cnvkit && \
     conda env create --file BALSAMIC/conda/varcall_py36.yaml -n varcall_py36 && \
     conda env create --file BALSAMIC/conda/annotate.yaml -n annotate && \
     conda env create --file BALSAMIC/conda/align.yaml -n align_qc && \

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -35,7 +35,7 @@ rule cnvkit_paired:
         namemap = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.sample_name_map"),
         tumor_cns = cnv_dir + tumor_bam + ".cns",
         tumor_cnr = cnv_dir + tumor_bam + ".cnr",
-        tumor_scatter = cnv_dir + tumor_bam + "-scatter.png",
+        tumor_scatter = cnv_dir + tumor_bam + "-scatter.pdf",
         tumor_diagram = cnv_dir + tumor_bam + "-diagram.pdf",
         gene_breaks_csv = cnv_dir + case_id + ".gene_breaks",
         gene_metrics_csv = cnv_dir + case_id + ".gene_metrics",

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -27,7 +27,7 @@ rule cnvkit_single:
         namemap = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.sample_name_map"),
         tumor_cns = cnv_dir + tumor_bam + ".cns",
         tumor_cnr = cnv_dir + tumor_bam + ".cnr",
-        tumor_scatter = cnv_dir + tumor_bam + "-scatter.png",
+        tumor_scatter = cnv_dir + tumor_bam + "-scatter.pdf",
         tumor_diagram = cnv_dir + tumor_bam + "-diagram.pdf",
         gene_breaks_csv = cnv_dir + case_id + ".gene_breaks",
         gene_metrics_csv = cnv_dir + case_id + ".gene_metrics",

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -294,7 +294,7 @@ def merge_dict_on_key(dict_1, dict_2, by_key):
 def find_file_index(file_path):
     indexible_files = {
         ".bam": [".bam.bai", ".bai"],
-        ".cram": [".cram.cai", ".cai"],
+        ".cram": [".cram.crai", ".crai"],
         ".vcf.gz": [".vcf.gz.tbi"],
         ".vcf": [".vcf.tbi"],
     }
@@ -439,15 +439,24 @@ def get_bioinfo_tools_list(conda_env_path) -> dict:
         with open(yaml_file, "r") as f:
             packages = yaml.safe_load(f).get("dependencies")
             for p in packages:
-                try:
-                    if "pip" in p:
-                        for pip_package in p:
-                            name, version = pip_package.split("==")
+                if isinstance(p, dict): 
+                    for pip_package in p["pip"]:
+                        name, version = pip_package.split("==")
+                        if name in bioinfo_tools:
+                            bioinfo_tools[name] = ",".join(set([bioinfo_tools[name], version]))
+                        else:
                             bioinfo_tools[name] = version
-                    else:
-                        name, version = p.split("==")
-                except ValueError:
-                    name, version = p, None
+                else:
+                    try:
+                        name = p.split("=")[0]
+                        version = "=".join(p.split("=")[1:])
+                    except ValueError:
+                        name, version = p, None
+                    finally:
+                        if name in bioinfo_tools:
+                            bioinfo_tools[name] = ",".join(set([bioinfo_tools[name], version]))
+                        else:
+                            bioinfo_tools[name] = version
     return bioinfo_tools
 
 

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -440,11 +440,14 @@ def get_bioinfo_tools_list(conda_env_path) -> dict:
             packages = yaml.safe_load(f).get("dependencies")
             for p in packages:
                 try:
-                    name, version = p.split("=")
+                    if "pip" in p:
+                        for pip_package in p:
+                            name, version = pip_package.split("==")
+                            bioinfo_tools[name] = version
+                    else:
+                        name, version = p.split("==")
                 except ValueError:
                     name, version = p, None
-                finally:
-                    bioinfo_tools[name] = version
     return bioinfo_tools
 
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -313,7 +313,7 @@ def test_get_conda_env_found(tmp_path):
     conda_env = get_conda_env(balsamic_env, 'cnvkit')
 
     # THEN It should return the conda env which has that pkg
-    assert conda_env == "varcall_py36"
+    assert conda_env == "varcall_cnvkit"
 
 
 def test_get_conda_env_not_found(tmp_path):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from BALSAMIC.utils.exc import BalsamicError
 
+from BALSAMIC.utils.constants import CONDA_ENV_PATH
+
 from BALSAMIC.utils.cli import (
     SnakeMake, CaptureStdout, iterdict, get_snakefile, createDir, write_json,
     get_config, recursive_default_dict, convert_defaultdict_to_regular_dict,
@@ -25,6 +27,16 @@ from BALSAMIC.utils.rule import (
     get_chrom, get_vcf, get_sample_type, get_conda_env, get_picard_mrkdup,
     get_script_path, get_result_dir, get_threads, get_delivery_id)
 
+def test_get_bioinfo_tools_list():
+    # GIVEN a path for conda env files
+    conda_env_path=CONDA_ENV_PATH
+
+    # WHEN getting dictionary of bioinformatic tools and their version
+    bioinfo_tools_dict = get_bioinfo_tools_list(conda_env_path)
+
+    # THEN assert it is a dictionary and versions are correct
+    assert isinstance(bioinfo_tools_dict, dict) 
+    assert bioinfo_tools_dict["cnvkit"] == "0.9.4"
 
 def test_get_delivery_id():
     # GIVEN a delivery id, a dummy file string, list of tags, and a snakemake wildcard_dict


### PR DESCRIPTION
### This PR:

Added: New conda env in container: varcall_cnvkit
Changed: Revert cnvkit back to 0.9.4

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
