### PR TITLE
Add sentieon env vars to config file to get in rules instead

### DIFF
--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_alignment.rule
@@ -18,8 +18,8 @@ rule sentieon_align_sort:
     params:
         tmpdir = tmp_dir,
         header = "'@RG\\tID:" +  "{sample}" + "\\tSM:" + "{sample}" + "\\tPL:ILLUMINAi'",
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_align_sort')
     log:
         bam_dir + "{sample}.bam.log"
@@ -48,8 +48,8 @@ rule sentieon_dedup:
     params:
         tmpdir = tmp_dir,
         housekeeper_id = {"id": "{sample}", "tags": "scout"},
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_dedup')
     log:
         bam_dir + "{sample}.dedup.bam.log"
@@ -80,8 +80,8 @@ rule sentieon_realign:
         bam = bam_dir + "{sample}.dedup.realign.bam",
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_realign')
     log:
         bam_dir + "{sample}.dedup.realign.bam.log"
@@ -113,8 +113,8 @@ rule sentieon_base_calibration:
         qual_recal_plot = bam_dir + "{sample}.dedup.realign.recal.pdf",
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_base_calibration')
     log:
         bam_dir + "{sample}.dedup.realign.recal.log"

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_germline.rule
@@ -13,8 +13,8 @@ rule sentieon_DNAscope:
         vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz",
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         sentieon_ml_dnascope = SENTIEON_DNASCOPE
     threads: get_threads(cluster_config, 'sentieon_DNAscope')
     log: 

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_qc_metrics.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_qc_metrics.rule
@@ -25,8 +25,8 @@ rule sentieon_wgs_metrics:
         min_base_qual = '10',
         gene_list = config["reference"]["refGene"],
         cov_threshold = repeat("--cov_thresh", [50, 100, 150, 200, 250]),
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_wgs_metrics')
     benchmark: 
         benchmark_dir + 'sentieon_wgs_metrics_' + "{sample}_wgs_metrics.tsv"

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_t_varcall.rule
@@ -29,9 +29,9 @@ rule sentieon_TNsnv_tumor_only:
     params:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
-        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]),
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNsnv_tumor_only')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
@@ -64,9 +64,9 @@ rule sentieon_TNhaplotyper_tumor_only:
     params:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
-        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]),
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper_tumor_only')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
@@ -99,9 +99,9 @@ rule sentieon_TNscope_tumor_only:
     params:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
-        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]),
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNscope_tumor_only')
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope_tumor_only.log"

--- a/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/sentieon/sentieon_tn_varcall.rule
@@ -20,8 +20,8 @@ rule sentieon_TN_corealign:
         bam = bam_dir + config["analysis"]["case_id"] + ".corealign.bam"
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TN_corealign')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".corealign.log"
@@ -54,8 +54,8 @@ rule sentieon_TNsnv:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNsnv')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"
@@ -88,8 +88,8 @@ rule sentieon_TNhaplotyper:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnhaplotyper.log"
@@ -125,9 +125,9 @@ rule sentieon_TNscope:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        variant_setting = "--min_init_normal_lod 0.5 --min_normal_lod 1.0 --min_init_tumor_lod 1.0 --min_tumor_lod 8"
+        variant_setting = "--min_init_normal_lod 0.5 --min_normal_lod 1.0 --min_init_tumor_lod 1.0 --min_tumor_lod 8",
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNscope')
     log: 
         vcf_dir + config["analysis"]["case_id"] + ".tnscope.log"
@@ -156,9 +156,9 @@ rule sentioen_filter_TNscope:
         tnscope_filtered_vcf = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".tnscope.vcf.gz",
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
-        sentieon_ml_tnscope = SENTIEON_TNSCOPE
+        sentieon_ml_tnscope = SENTIEON_TNSCOPE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_filter_TNscope')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnscope.filtered.log",

--- a/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
@@ -13,8 +13,8 @@ rule sentieon_umi_consensus_call:
     output:
         fastq_consensus = umi_dir + '{sample}.consensuscall.fastq.gz',
     params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + 'bin/sentieon',
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         tag = 'XR',
         ip_format = 'SAM',
         sample_id = '{sample}'
@@ -38,8 +38,8 @@ rule sentieon_umi_consensus_align:
     output:
         align_consensus = umi_dir + '{sample}.consensusalign.bam',
     params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + 'bin/sentieon',
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         sheader = "'@RG\\tID:Group\\tSM:{sample}\\tLB:TargetPanel\\tPL:ILLUMINA'",
         ip_bases = '1000000',
         sample_id = '{sample}'

--- a/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
@@ -13,8 +13,8 @@ rule sentieon_umi_extract:
     output:
         ds_umi = umi_dir + '{sample}.umiextract.fastq.gz'
     params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + 'bin/sentieon',
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         ds_params= ['-d', '3M2S+T,3M2S+T'],
         sample_id = '{sample}'
     log: 
@@ -39,8 +39,8 @@ rule sentieon_umi_align:
     output:
         align_umi = temp(umi_dir + '{sample}.umialign.sam')
     params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + 'bin/sentieon',
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         sheader = "'@RG\\tID:Group\\tSM:{sample}\\tLB:TargetPanel\\tPL:ILLUMINA'",
         ip_bases = '1000000',
         sample_id = '{sample}'

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -14,8 +14,8 @@ rule sentieon_umi_tnscope:
     output:
          vcf = vcf_dir + '{sample}.TNscope.umi.vcf.gz',
     params:
-        sentieon_exec = SENTIEON_INSTALL_DIR + 'bin/sentieon',
-        sentieon_lic = SENTIEON_LICENSE,
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
         algo = 'TNscope',
         tAF = '0.0005',
         TL = '0.5',

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -133,8 +133,8 @@ rule sentieon_DNAscope:
         vcf = vcf_dir + "SNV.germline.{sample}.dnascope.vcf.gz",
     params:
         tmpdir = tmp_dir,
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"]
     threads: get_threads(cluster_config, 'sentieon_DNAscope')
     log: 
         vcf_dir + "{sample}.dnascope.log"

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -242,8 +242,8 @@ rule sentieon_TNhaplotyper:
         tmpdir = tmp_dir,
         tumor = get_sample_type(config["samples"], "tumor"),
         normal = get_sample_type(config["samples"], "normal"),
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnhaplotyper.log"

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -199,8 +199,8 @@ rule sentieon_TNhaplotyper_tumor_only:
         tmpdir = tmp_dir, 
         tumor = get_sample_type(config["samples"], "tumor"),
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]), 
-        sentieon_exec = SENTIEON_INSTALL_DIR + "/bin/sentieon",
-        sentieon_lic = SENTIEON_LICENSE, 
+        sentieon_exec = config["SENTIEON_INSTALL_DIR"] + "/bin/sentieon",
+        sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper_tumor_only')
     log:
         vcf_dir + config["analysis"]["case_id"] + ".tnsnv.log"

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -115,7 +115,7 @@ class SnakeMake:
             snakemake_config_key_value = f' --config disable_variant_caller={self.disable_variant_caller} '
 
         if self.use_singularity:
-            self.singularity_arg = "--use-singularity --singularity-args ' --clean-env "
+            self.singularity_arg = "--use-singularity --singularity-args ' --cleanenv "
             for bind_path in self.singularity_bind:
                 self.singularity_arg += " --bind {}:{}".format(
                     bind_path, bind_path)

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -115,7 +115,7 @@ class SnakeMake:
             snakemake_config_key_value = f' --config disable_variant_caller={self.disable_variant_caller} '
 
         if self.use_singularity:
-            self.singularity_arg = "--use-singularity --singularity-args '"
+            self.singularity_arg = "--use-singularity --singularity-args ' --clean-env "
             for bind_path in self.singularity_bind:
                 self.singularity_arg += " --bind {}:{}".format(
                     bind_path, bind_path)

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -2,8 +2,11 @@
 # coding: utf-8
 
 import os
-from BALSAMIC.utils.rule import get_vcf
+import logging
+
 from BALSAMIC.utils.rule import get_result_dir
+
+LOG = logging.getLogger(__name__)
 
 shell.prefix("set -eo pipefail; ")
 
@@ -31,12 +34,11 @@ if len(cluster_config.keys()) == 0:
     cluster_config = config
 
 try:
-    SENTIEON_LICENSE = os.environ["SENTIEON_LICENSE"]
-    SENTIEON_INSTALL_DIR = os.environ["SENTIEON_INSTALL_DIR"]
+    config["SENTIEON_LICENSE"] = os.environ["SENTIEON_LICENSE"]
+    config["SENTIEON_INSTALL_DIR"] = os.environ["SENTIEON_INSTALL_DIR"]
 except Exception as error:
-    sentieon = False
-    LOG.warn("Set environment variables SENTIEON_LICENSE and SENTIEON_INSTALL_DIR to run SENTIEON variant callers")
-
+    LOG.error("ERROR: Set SENTIEON_LICENSE and SENTIEON_INSTALL_DIR environment variable to run this pipeline.")
+    raise
 
 # Define umiworkflow rules
 

--- a/BALSAMIC/workflows/VariantCalling.smk
+++ b/BALSAMIC/workflows/VariantCalling.smk
@@ -45,8 +45,8 @@ if len(cluster_config.keys()) == 0:
     cluster_config = config
 
 try:
-    SENTIEON_LICENSE = os.environ["SENTIEON_LICENSE"]
-    SENTIEON_INSTALL_DIR = os.environ["SENTIEON_INSTALL_DIR"]
+    config["SENTIEON_LICENSE"] = os.environ["SENTIEON_LICENSE"]
+    config["SENTIEON_INSTALL_DIR"] = os.environ["SENTIEON_INSTALL_DIR"]
 except Exception as error:
     sentieon = False
     LOG.warn("Set environment variables SENTIEON_LICENSE and SENTIEON_INSTALL_DIR to run SENTIEON variant callers")

--- a/BALSAMIC/workflows/VariantCalling_sentieon.smk
+++ b/BALSAMIC/workflows/VariantCalling_sentieon.smk
@@ -9,9 +9,7 @@ from yapf.yapflib.yapf_api import FormatFile
 from BALSAMIC.utils.cli import write_json
 from BALSAMIC.utils.rule import get_rule_output
 from BALSAMIC.utils.rule import get_result_dir
-from BALSAMIC.utils.rule import get_result_dir
 from BALSAMIC.utils.rule import get_vcf
-from BALSAMIC import __version__ as bv
 
 shell.prefix("set -eo pipefail; ")
 
@@ -35,10 +33,10 @@ vep_dir = get_result_dir(config) + "/vep/"
 singularity_image = config['singularity']['image'] 
 
 try:
-    SENTIEON_LICENSE = os.environ["SENTIEON_LICENSE"]
-    SENTIEON_INSTALL_DIR = os.environ["SENTIEON_INSTALL_DIR"]
+    config["SENTIEON_LICENSE"] = os.environ["SENTIEON_LICENSE"]
+    config["SENTIEON_INSTALL_DIR"] = os.environ["SENTIEON_INSTALL_DIR"]
 except Exception as error:
-    print("ERROR: Set Environment variable to run this pipeline.")
+    LOG.error("ERROR: Set SENTIEON_LICENSE and SENTIEON_INSTALL_DIR environment variable to run this pipeline.")
     raise
 
 SENTIEON_DNASCOPE = rule_dir + 'assets/sentieon_models/SentieonDNAscopeModelBeta0.4a-201808.05.model'


### PR DESCRIPTION
### This PR:

Changed:

- Sentieon env vars moved to config

Added:

- Option `--clean-env` now added to each job

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
