### PR TITLE
crush redundant variables in rules and have one in the main workflow

### DIFF
--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -1,11 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from pathlib import Path
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_threads
-
-
 def picard_flag(picarddup):
     if picarddup == "mrkdup":
         return "FALSE"

--- a/BALSAMIC/snakemake_rules/align/bwa_mem.rule
+++ b/BALSAMIC/snakemake_rules/align/bwa_mem.rule
@@ -3,10 +3,8 @@
 
 from pathlib import Path
 from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_threads
 
-picarddup = get_picard_mrkdup(config)
 
 def picard_flag(picarddup):
     if picarddup == "mrkdup":

--- a/BALSAMIC/snakemake_rules/align/sentieon_alignment.rule
+++ b/BALSAMIC/snakemake_rules/align/sentieon_alignment.rule
@@ -1,10 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from pathlib import Path
-from BALSAMIC.utils.rule import get_threads
-
-
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 rule sentieon_align_sort:
     input:

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter.rule
@@ -4,10 +4,6 @@
 
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_threads
-from BALSAMIC.utils.models import VarCallerFilter
-from BALSAMIC.utils.constants import VARDICT_SETTINGS
-
-VARDICT = VarCallerFilter.parse_obj(VARDICT_SETTINGS)
 
 rule ngs_filter_vardict:
   input:

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter.rule
@@ -2,9 +2,6 @@
 # coding: utf-8
 # NGS filters for various scenarios
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_threads
-
 rule ngs_filter_vardict:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.vcf.gz",

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -2,8 +2,6 @@
 # coding: utf-8
 # VEP annotation module. Annotate all VCFs generated through VEP
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_threads
 from BALSAMIC.utils.constants import VCFANNO_TOML
 
 rule vep_somatic:

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -2,8 +2,6 @@
 # coding: utf-8
 # VEP annotation module. Annotate all VCFs generated through VEP
 
-from BALSAMIC.utils.constants import VCFANNO_TOML
-
 rule vep_somatic:
   input:
     vcf = vcf_dir + "{var_type}.somatic.{case_name}.{var_caller}.vcf.gz",

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 rule RealignerTargetCreator:
   input:
     bam = bam_dir + "{sample}" + ".sorted." + picarddup + ".bam",

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -1,9 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
-
-picarddup = get_picard_mrkdup(config)
+from BALSAMIC.utils.rule import get_conda_env
 
 rule RealignerTargetCreator:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/contest.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/contest.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 rule GATK_contest:
   input:
     bamN = bam_dir + "normal.merged.bam",

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_threads
-
 if 'quality_trim' in config['QC'].keys():
     fastp_param_qc = list()
     fastp_param_adapter = list()

--- a/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastqc.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 rule fastqc:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/mosdepth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/mosdepth.rule
@@ -1,9 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
-
-picarddup = get_picard_mrkdup(config)
+from BALSAMIC.utils.rule import get_conda_env
 
 rule mosdepth_coverage:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/mosdepth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/mosdepth.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 rule mosdepth_coverage:
   input:
     bam = bam_dir + "{sample}" + ".sorted." + picarddup + ".bam",

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -2,18 +2,15 @@
 # coding: utf-8
 
 from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_picard_mrkdup
 
-picarddup = get_picard_mrkdup(config)
-
-picard_metrics_wildcard = ["alignment_summary_metrics", "base_distribution_by_cycle_metrics",
-                           "base_distribution_by_cycle.pdf", "insert_size_histogram.pdf", "insert_size_metrics",
-                           "quality_by_cycle_metrics",
-                           "quality_by_cycle.pdf", "quality_distribution_metrics", "quality_distribution.pdf"]
 multiqc_input = []
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format
 if config["analysis"]["sequencing_type"] == 'wgs':
+    picard_metrics_wildcard = ["alignment_summary_metrics", "base_distribution_by_cycle_metrics",
+                               "base_distribution_by_cycle.pdf", "insert_size_histogram.pdf", "insert_size_metrics",
+                               "quality_by_cycle_metrics",
+                               "quality_by_cycle.pdf", "quality_distribution_metrics", "quality_distribution.pdf"]
     # fastqc metrics
     multiqc_input.extend(expand(fastqc_dir + "{sample}_{read_num}_fastqc.zip", sample=config["samples"], read_num=[1, 2]))
 

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 multiqc_input = []
 
 # Following rule will take input fastq files, align them using bwa mem, and convert the output to sam format

--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -1,9 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
-
-picarddup = get_picard_mrkdup(config)
+from BALSAMIC.utils.rule import get_conda_env
 
 def picard_flag(picarddup):
   if picarddup == "mrkdup":

--- a/BALSAMIC/snakemake_rules/quality_control/picard.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 def picard_flag(picarddup):
   if picarddup == "mrkdup":
       return "FALSE"

--- a/BALSAMIC/snakemake_rules/quality_control/picard_wgs.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard_wgs.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 picard_metrics_wildcard = ["alignment_summary_metrics", "base_distribution_by_cycle_metrics",
                            "base_distribution_by_cycle.pdf", "insert_size_histogram.pdf",
                            "insert_size_metrics", "quality_by_cycle_metrics",

--- a/BALSAMIC/snakemake_rules/quality_control/picard_wgs.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/picard_wgs.rule
@@ -3,8 +3,10 @@
 
 from BALSAMIC.utils.rule import get_conda_env
 
-picard_metrics_wildcard = ["alignment_summary_metrics", "base_distribution_by_cycle_metrics", "base_distribution_by_cycle.pdf", "insert_size_histogram.pdf", "insert_size_metrics", "quality_by_cycle_metrics", "quality_by_cycle.pdf", "quality_distribution_metrics", "quality_distribution.pdf"]
-
+picard_metrics_wildcard = ["alignment_summary_metrics", "base_distribution_by_cycle_metrics",
+                           "base_distribution_by_cycle.pdf", "insert_size_histogram.pdf",
+                           "insert_size_metrics", "quality_by_cycle_metrics",
+                           "quality_by_cycle.pdf", "quality_distribution_metrics", "quality_distribution.pdf"]
 
 rule CollectMultipleMetrics:
     input:

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -1,9 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
-
-picarddup = get_picard_mrkdup(config)
+from BALSAMIC.utils.rule import get_conda_env
 
 rule sambamba_panel_depth:
   input:

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 rule sambamba_panel_depth:
   input:
     bam = bam_dir + "{sample}" + ".sorted." + picarddup + ".bam",

--- a/BALSAMIC/snakemake_rules/quality_control/sentieon_qc_metrics.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sentieon_qc_metrics.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_threads
-
-
 def repeat(param, values):
     param_values = []
     

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -3,6 +3,9 @@
 
 from BALSAMIC.utils.rule import get_conda_env
 
+fasta = config["reference"]["reference_genome"]
+refflat = config["reference"]["refflat"]
+
 if config["analysis"]["sequencing_type"] == 'wgs':
     normal_bam = "{normal}.dedup.realign".format(normal = get_sample_type(config["samples"], "normal")[0])
     tumor_bam = "{tumor}.dedup.realign".format(tumor = get_sample_type(config["samples"], "tumor")[0])

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 fasta = config["reference"]["reference_genome"]
 refflat = config["reference"]["refflat"]
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -1,11 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env, get_chrom
-
-fasta = config["reference"]["reference_genome"]
-refflat = config["reference"]["refflat"]
-case_id = config["analysis"]["case_id"]
+from BALSAMIC.utils.rule import get_conda_env
 
 if config["analysis"]["sequencing_type"] == 'wgs':
     normal_bam = "{normal}.dedup.realign".format(normal = get_sample_type(config["samples"], "normal")[0])
@@ -22,32 +18,32 @@ else:
 
 rule cnvkit_paired:
     input:
-        fasta = fasta, 
-        refflat = refflat, 
+        fasta = config["reference"]["reference_genome"],
+        refflat = config["reference"]["refflat"],
         bamN = bam_dir + normal_bam + ".bam", 
         bamT = bam_dir + tumor_bam + ".bam"
     output:
-        vcf = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.vcf.gz"),
-        namemap = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.sample_name_map"),
+        vcf = temp(vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz"),
+        namemap = temp(vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.sample_name_map"),
         cns = cnv_dir + tumor_bam + ".cns",
         cnr = cnv_dir + tumor_bam + ".cnr",
         scatter = cnv_dir + tumor_bam + "-scatter.pdf",
         diagram = cnv_dir + tumor_bam + "-diagram.pdf",
-        gene_breaks = cnv_dir + case_id + ".gene_breaks",
-        gene_metrics = cnv_dir + case_id + ".gene_metrics",
+        gene_breaks = cnv_dir + config["analysis"]["case_id"] + ".gene_breaks",
+        gene_metrics = cnv_dir + config["analysis"]["case_id"] + ".gene_metrics",
     params:
-        housekeeper_id = {"id": case_id, "tags": "cnv"},
+        housekeeper_id = {"id": config["analysis"]["case_id"], "tags": "cnv"},
         tmpdir = tmp_dir,
         extra = cnvkit_params,
         target = config["panel"]["capture_kit"] if "panel" in config else "None", 
-        name = case_id,
+        name = config["analysis"]["case_id"],
         normal_name = normal_bam,
         tumor_name = tumor_bam,
         cnv_dir = cnv_dir,
         conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
     singularity: singularity_image
     benchmark:
-        benchmark_dir + "cnvkit_paired_" + case_id + ".cnvkit_paired.tsv"
+        benchmark_dir + "cnvkit_paired_" + config["analysis"]["case_id"] + ".cnvkit_paired.tsv"
     shell:
         "source activate {params.conda}; "
         "rand_str=$(openssl rand -hex 5); "

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 if config["analysis"]["sequencing_type"] == 'wgs':
     tumor_bam = "{tumor}.dedup.realign".format(tumor = get_sample_type(config["samples"], "tumor")[0])
     cnvkit_params = " --method wgs "

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -3,11 +3,6 @@
 
 from BALSAMIC.utils.rule import get_conda_env
 
-fasta = config["reference"]["reference_genome"]
-refflat = config["reference"]["refflat"]
-wgs_calling_interval = config["reference"]["wgs_calling_interval"]
-case_id = config["analysis"]["case_id"]
-
 if config["analysis"]["sequencing_type"] == 'wgs':
     tumor_bam = "{tumor}.dedup.realign".format(tumor = get_sample_type(config["samples"], "tumor")[0])
     cnvkit_params = " --method wgs "
@@ -17,32 +12,32 @@ else:
 
 rule cnvkit_single:
     input:
-        fasta = fasta, 
-        refflat = refflat, 
-        wgs_calling_interval = wgs_calling_interval, 
+        fasta = config["reference"]["reference_genome"],
+        refflat = config["reference"]["refflat"],
+        wgs_calling_interval = config["reference"]["wgs_calling_interval"],
         bamT = bam_dir + tumor_bam + ".bam", 
     output:
-        vcf = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.vcf.gz"),
-        namemap = temp(vcf_dir + "CNV.somatic." + case_id + ".cnvkit.sample_name_map"),
+        vcf = temp(vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.vcf.gz"),
+        namemap = temp(vcf_dir + "CNV.somatic." + config["analysis"]["case_id"] + ".cnvkit.sample_name_map"),
         cns = cnv_dir + tumor_bam + ".cns",
         cnr = cnv_dir + tumor_bam + ".cnr",
         scatter = cnv_dir + tumor_bam + "-scatter.pdf",
         diagram = cnv_dir + tumor_bam + "-diagram.pdf",
-        gene_breaks = cnv_dir + case_id + ".gene_breaks",
-        gene_metrics = cnv_dir + case_id + ".gene_metrics",
+        gene_breaks = cnv_dir + config["analysis"]["case_id"] + ".gene_breaks",
+        gene_metrics = cnv_dir + config["analysis"]["case_id"] + ".gene_metrics",
     params:
-        housekeeper_id = {"id": case_id, "tags": "cnv"},
+        housekeeper_id = {"id": config["analysis"]["case_id"], "tags": "cnv"},
         tmpdir = tmp_dir,
         extra = cnvkit_params,
         refcnn = cnv_dir + "FlatReference.cnn",
         target = config["panel"]["capture_kit"] if "panel" in config else "None", 
-        name = case_id,
+        name = config["analysis"]["case_id"],
         tumor_name = tumor_bam,
         cnv_dir = cnv_dir,
         conda = get_conda_env(config["conda_env_yaml"], "cnvkit"),
     singularity: singularity_image
     benchmark:
-        benchmark_dir + 'cnvkit_single_' + case_id + ".cnvkit_single.tsv"
+        benchmark_dir + 'cnvkit_single_' + config["analysis"]["case_id"] + ".cnvkit_single.tsv"
     shell:
         "source activate {params.conda}; "
         "rand_str=$(openssl rand -hex 5); "

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -1,10 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_threads
-
-
 rule haplotypecaller:
     input:
         fa = config["reference"]["reference_genome"],

--- a/BALSAMIC/snakemake_rules/variant_calling/germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/germline.rule
@@ -1,14 +1,9 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-import os
 from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_threads
 
-chromlist = config["panel"]["chrom"]
-picarddup = get_picard_mrkdup(config)
-capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
 
 rule haplotypecaller:
     input:

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -4,14 +4,8 @@
 from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
 
-picarddup = get_picard_mrkdup(config)
-
 picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
-normal_sample = get_sample_type(config["samples"], "normal")[0]
-tumor_sample = get_sample_type(config["samples"], "tumor")[0]
-case_id = config["analysis"]["case_id"]
-
 
 rule mergeBam_normal_gatk:
   input:
@@ -82,7 +76,7 @@ rule mergeBam_tumor:
 rule mergeBam_tumor_gatk:
   input:
     bamT = bam_dir + "{mysample}.sorted.{picardstr}.bsrcl.bam".format(mysample = tumor_sample,
-                                                                            picardstr = picarddup) 
+                                                                      picardstr = picarddup)
   output:
     bamT = bam_dir + "tumor.sorted." + picarddup + ".bsrcl.merged.bam",
   params:

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
-
 picard_extra_normal=" ".join(["RGPU=ILLUMINAi", "RGID=NORMAL","RGSM=NORMAL", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_conda_env
-
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 tumor_sample = get_sample_type(config["samples"], "tumor")[0]
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -2,12 +2,10 @@
 # coding: utf-8
 
 from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_conda_env, get_picard_mrkdup
+from BALSAMIC.utils.rule import get_conda_env
 
-picarddup = get_picard_mrkdup(config)
 picard_extra_tumor=" ".join(["RGPU=ILLUMINAi", "RGID=TUMOR",  "RGSM=TUMOR", "RGPL=ILLUMINAi", "RGLB=ILLUMINAi"])
 tumor_sample = get_sample_type(config["samples"], "tumor")[0]
-case_id = config["analysis"]["case_id"]
 
 
 rule mergeBam_tumor:

--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_germline.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_threads
-
 rule sentieon_DNAscope:
     input:
         ref = config["reference"]["reference_genome"],

--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_t_varcall.rule
@@ -1,10 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_threads
-
-
 def get_pon(config):
     """ return pon cli string, complete with file """
     if "PON" in config["analysis"]:

--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_tn_varcall.rule
@@ -1,10 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_threads
-
-
 rule sentieon_TN_corealign:
     input:
         ref = config["reference"]["reference_genome"],

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_sample_type
-
 normal_bam = "normal.merged.bam"
 tumor_bam = "tumor.merged.bam"
 

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
@@ -1,9 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_sample_type
-
 tumor_bam = "tumor.merged.bam"
 
 if config["analysis"]["sequencing_type"] == 'wgs':

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -7,9 +7,6 @@ from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_threads
 
-picarddup = get_picard_mrkdup(config)
-chromlist = config["panel"]["chrom"]
-capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
 
 rule vardict_tumor_normal:
   input:

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_normal.rule
@@ -1,13 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-import os
-from BALSAMIC.utils.rule import get_picard_mrkdup
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_threads
-
-
 rule vardict_tumor_normal:
   input:
     fa = config["reference"]["reference_genome"],

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -3,15 +3,9 @@
 
 import os
 
-from BALSAMIC.utils.rule import get_picard_mrkdup
 from BALSAMIC.utils.rule import get_conda_env
 from BALSAMIC.utils.rule import get_sample_type
 from BALSAMIC.utils.rule import get_threads
-
-picarddup = get_picard_mrkdup(config)
-chromlist = config["panel"]["chrom"]
-capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
-
 
 def get_pon(config):
     """ return pon cli string, complete with file """

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_tumor_only.rule
@@ -1,12 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-import os
-
-from BALSAMIC.utils.rule import get_conda_env
-from BALSAMIC.utils.rule import get_sample_type
-from BALSAMIC.utils.rule import get_threads
-
 def get_pon(config):
     """ return pon cli string, complete with file """
     if "PON" in config["analysis"]:

--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -1,8 +1,6 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-from BALSAMIC.utils.rule import get_conda_env
-
 rule split_bed_by_chrom:
     input:
         bed = config["panel"]["capture_kit"],

--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -1,14 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 
-__author__ = "Hassan Foroughi Asl"
-
-import os
-from BALSAMIC.utils.rule import get_conda_env,get_picard_mrkdup
-
-chromlist = config["panel"]["chrom"]
-capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
-picarddup = get_picard_mrkdup(config)
+from BALSAMIC.utils.rule import get_conda_env
 
 rule split_bed_by_chrom:
     input:

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -9,7 +9,7 @@ from yapf.yapflib.yapf_api import FormatFile
 from snakemake.exceptions import RuleException, WorkflowError
 from BALSAMIC.utils.exc import BalsamicError
 from BALSAMIC.utils.cli import write_json
-from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir, get_vcf, get_picard_mrkdup)
+from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir, get_vcf, get_picard_mrkdup, get_sample_type)
 from BALSAMIC.utils.models import VarCallerFilter
 from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY, VARDICT_SETTINGS
 

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -35,7 +35,8 @@ singularity_image = config['singularity']['image']
 picarddup = get_picard_mrkdup(config)
 VARDICT= VarCallerFilter.parse_obj(VARDICT_SETTINGS)
 capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
-normal_sample = get_sample_type(config["samples"], "normal")[0]
+if config['analysis']['analysis_type'] == "paired":
+    normal_sample = get_sample_type(config["samples"], "normal")[0]
 tumor_sample = get_sample_type(config["samples"], "tumor")[0]
 case_id = config["analysis"]["case_id"]
 

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -34,7 +34,8 @@ singularity_image = config['singularity']['image']
 # rule related variables
 picarddup = get_picard_mrkdup(config)
 VARDICT= VarCallerFilter.parse_obj(VARDICT_SETTINGS)
-capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
+if config["analysis"]["sequencing_type"] != "wgs":
+    capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
 if config['analysis']['analysis_type'] == "paired":
     normal_sample = get_sample_type(config["samples"], "normal")[0]
 tumor_sample = get_sample_type(config["samples"], "tumor")[0]

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -7,9 +7,12 @@ from pathlib import Path
 from yapf.yapflib.yapf_api import FormatFile
 
 from snakemake.exceptions import RuleException, WorkflowError
+
 from BALSAMIC.utils.exc import BalsamicError
 from BALSAMIC.utils.cli import write_json
-from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir, get_vcf, get_picard_mrkdup, get_sample_type)
+from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir,
+                                 get_vcf, get_picard_mrkdup, get_sample_type,
+                                 get_conda_env, get_threads)
 from BALSAMIC.utils.models import VarCallerFilter
 from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY, VARDICT_SETTINGS
 

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -14,7 +14,7 @@ from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_resul
                                  get_vcf, get_picard_mrkdup, get_sample_type,
                                  get_conda_env, get_threads)
 from BALSAMIC.utils.models import VarCallerFilter
-from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY, VARDICT_SETTINGS
+from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY, VARDICT_SETTINGS, VCFANNO_TOML
 
 shell.prefix("set -eo pipefail; ")
 

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -9,8 +9,9 @@ from yapf.yapflib.yapf_api import FormatFile
 from snakemake.exceptions import RuleException, WorkflowError
 from BALSAMIC.utils.exc import BalsamicError
 from BALSAMIC.utils.cli import write_json
-from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir, get_vcf)
-from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY
+from BALSAMIC.utils.rule import (get_variant_callers, get_rule_output, get_result_dir, get_vcf, get_picard_mrkdup)
+from BALSAMIC.utils.models import VarCallerFilter
+from BALSAMIC.utils.constants import SENTIEON_DNASCOPE, SENTIEON_TNSCOPE, RULE_DIRECTORY, VARDICT_SETTINGS
 
 shell.prefix("set -eo pipefail; ")
 
@@ -29,6 +30,14 @@ qc_dir = result_dir + "qc/"
 delivery_dir = get_result_dir(config) + "/delivery/"
 
 singularity_image = config['singularity']['image']
+
+# rule related variables
+picarddup = get_picard_mrkdup(config)
+VARDICT= VarCallerFilter.parse_obj(VARDICT_SETTINGS)
+capture_kit = os.path.split(config["panel"]["capture_kit"])[1]
+normal_sample = get_sample_type(config["samples"], "normal")[0]
+tumor_sample = get_sample_type(config["samples"], "tumor")[0]
+case_id = config["analysis"]["case_id"]
 
 # Declare sentieon variables
 sentieon = True
@@ -70,6 +79,7 @@ if config["analysis"]["sequencing_type"] == "wgs":
 
     align_rules = ["snakemake_rules/align/sentieon_alignment.rule"]
 else:
+    chromlist = config["panel"]["chrom"]
     qc_rules.extend([
         "snakemake_rules/quality_control/GATK.rule",
         "snakemake_rules/quality_control/picard.rule",


### PR DESCRIPTION
### This PR:

Changed:

- move redundant variables into main workflow

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
