### PR TITLE
Refactor/umiworkflow rules

### DIFF
--- a/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
+++ b/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
@@ -9,11 +9,11 @@ from BALSAMIC.utils.rule import get_threads
 # Generate tables for AF scatterplots
 rule bcftools_query_generatebackgroundaf_umitable:
     input:
-        vcf = vcf_dir + "{sample}.{var_caller}.consensusfiltered.vcf.gz"
+        vcf = vcf_dir + "{sample}.{var_caller}.{step}.vcf.gz"
     output:
-        AF = table_dir + "{sample}.{var_caller}.consensusfiltered.AFtable.txt"
+        AF = table_dir + "{sample}.{var_caller}.{step}.AFtable.txt"
     benchmark:
-        Path(benchmark_dir + "bcftools_query_generatebackgroundaf_umitable_{sample}_{var_caller}.tsv").as_posix()
+        Path(benchmark_dir + "bcftools_query_generatebackgroundaf_umitable_{sample}_{var_caller}_{step}.tsv").as_posix()
     singularity:
         singularity_image
     params:
@@ -27,10 +27,9 @@ rule bcftools_query_generatebackgroundaf_umitable:
     shell:
         """
 source activate {params.conda};
-
 bcftools query \
 --regions-file {params.validated_set} \
--f \"%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%AF\\t%AD{{0}}\\t%AD{{1}}]\" \
+-f \"%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%AF\\t%AD{{0}}\\t%AD{{1}}]\n\" \
 {input.vcf} | \
 awk -v file={params.sample_id} \
 \'{{print $1\":\"$2\"_\"$3\"->\"$4\"\\t\"$8/($7+$8)\"\\t\"file}}\' \

--- a/BALSAMIC/snakemake_rules/umi/qc_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/qc_umi.rule
@@ -114,10 +114,10 @@ END{{printf(\"{params.sample_id}_meandepth: \"sum/NR)}}' \
 rule bcftools_query_calculatenoiseAF_umi:
     input:
         umiextract = vcf_dir + "{sample}.TNscope.umialign.vcf.gz",
-        consensuscall = vcf_dir + "{sample}.TNscope.consensusalign.vcf.gz"
+        consensuscall = vcf_dir + "{sample}.TNscope.consensusfiltered.vcf.gz"
     output:
         umiextractAF = temp (qc_dir + "{sample}.TNscope.umialign.AF.txt"),
-        consensuscallAF = temp (qc_dir + "{sample}.TNscope.consensusalign.AF.txt"),
+        consensuscallAF = temp (qc_dir + "{sample}.TNscope.consensusfiltered.AF.txt"),
         noiseAF = qc_dir + "{sample}.TNscope.noiseAF"
     benchmark:
         Path(benchmark_dir + "bcftools_query_calculatenoiseAF_umi_{sample}.tsv").as_posix()
@@ -158,7 +158,7 @@ END {{print(\"NoiseAF: \"(sum1/f1_nr)/(sum2/(NR-f1_nr)))}}' \
 rule seaborn_densityplot_umi:
     input:
         table1 = qc_dir + "{sample}.TNscope.umialign.AF.txt",
-        table2 = qc_dir + "{sample}.TNscope.consensusalign.AF.txt"
+        table2 = qc_dir + "{sample}.TNscope.consensusfiltered.AF.txt"
     output:
         AF_plot = plot_dir + "{sample}.TNscope.AFplot.pdf"
     benchmark:
@@ -170,4 +170,4 @@ rule seaborn_densityplot_umi:
     message:
         "Density AF plots for sample {params.sample_id}"
     run:
-        get_densityplot(input.table1, input.table2, "umiextracted", "consensuscalled", output.AF_plot)
+        get_densityplot(input.table1, input.table2, "umiextracted", "consensuscallfiltered", output.AF_plot)

--- a/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
@@ -19,7 +19,7 @@ rule sentieon_consensuscall_umi:
     benchmark:
         Path(benchmark_dir + "sentieon_consensuscall_umi_{sample}.tsv").as_posix()
     params:
-        sentieon_exec = config["SENTIEON_INSTALL_DIR"],
+        sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         tag = paramsumi.consensuscall.tag, 
         ip_format = paramsumi.consensuscall.align_format,
@@ -49,7 +49,7 @@ rule sentieon_bwa_umiconsensus:
     benchmark:
         Path(benchmark_dir + "sentieon_bwa_umiconsensus_{sample}.tsv").as_posix()
     params:
-        sentieon_exec = config["SENTIEON_INSTALL_DIR"],
+        sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         sheader = paramsumi.common.align_header,
         ip_bases = paramsumi.common.align_intbases,

--- a/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
@@ -20,7 +20,7 @@ rule sentieon_umiextract:
     benchmark:
         Path(benchmark_dir + "sentieon_umiextract_{sample}.tsv").as_posix()
     params:
-        sentieon_exec = config["SENTIEON_INSTALL_DIR"],
+        sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         ds_params= paramsumi.umiextract.read_structure,
         sample_id = "{sample}"
@@ -45,7 +45,7 @@ rule sentieon_bwa_umiextract:
     benchmark:
         Path(benchmark_dir + "sentieon_bwa_umiextract_{sample}.tsv").as_posix()
     params:
-        sentieon_exec = config["SENTIEON_INSTALL_DIR"],
+        sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         sheader = paramsumi.common.align_header,
         ip_bases = paramsumi.common.align_intbases,

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -19,7 +19,7 @@ rule sentieon_tnscope_umi:
     benchmark:
         Path(benchmark_dir + "sentieon_tnscope_{sample}_{step}.tsv").as_posix()
     params:
-        sentieon_exec = config["SENTIEON_INSTALL_DIR"],
+        sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         tumor_af = paramsumi.common.filter_tumor_af,
         algo = paramsumi.tnscope.algo,

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -34,7 +34,7 @@ if len(cluster_config.keys()) == 0:
 
 try:
     config["SENTIEON_LICENSE"] = os.environ["SENTIEON_LICENSE"]
-    config["SENTIEON_INSTALL_DIR"] = Path(os.environ["SENTIEON_INSTALL_DIR"], "bin", "sentieon").as_posix()
+    config["SENTIEON_EXEC"] = Path(os.environ["SENTIEON_INSTALL_DIR"], "bin", "sentieon").as_posix()
 except Exception as error:
     LOG.error("ERROR: Set SENTIEON_LICENSE and SENTIEON_INSTALL_DIR environment variable to run this pipeline.")
     raise

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -59,20 +59,20 @@ generate_tables = ["snakemake_rules/umi/generate_AF_tables.rule"]
 # Define wildcards
 SAMPLES = config["samples"]
 VAR_CALLER = ["TNscope","vardict"]
-STEPS = ["umialign","consensusfiltered"]
-#STEPS = ["consensusfiltered"]
+ALL_STEPS = ["consensusalign","consensusfiltered", "umialign"]
+FILTERED_STEPS = ["consensusalign","consensusfiltered"]
 
 # Define outputs
-analysis_output = [ expand(vcf_dir + "{sample}.{var_caller}.{step}.vcf.gz", sample=SAMPLES, var_caller=VAR_CALLER, step = STEPS),
-expand(vep_dir + "{sample}.{var_caller}.{step}.{filler}.vcf.gz", sample=SAMPLES, var_caller=VAR_CALLER, filler=["all","pass"], step=STEPS),
-expand(qc_dir + "{sample}.{step}.umimetrics", sample=SAMPLES, step=STEPS),
-expand(qc_dir + "{sample}.{step}.collect_hsmetric_umi", sample=SAMPLES, step=STEPS),
-expand(qc_dir + "{sample}.{step}.mean_family_depth", sample=SAMPLES, step = STEPS),
+analysis_output = [ expand(vcf_dir + "{sample}.{var_caller}.{step}.vcf.gz", sample=SAMPLES, var_caller=VAR_CALLER, step = ALL_STEPS),
+expand(vep_dir + "{sample}.{var_caller}.{step}.{filler}.vcf.gz", sample=SAMPLES, var_caller=VAR_CALLER, filler=["all","pass"], step= FILTERED_STEPS),
+expand(qc_dir + "{sample}.{step}.umimetrics", sample=SAMPLES, step=FILTERED_STEPS),
+expand(qc_dir + "{sample}.{step}.collect_hsmetric_umi", sample=SAMPLES, step=FILTERED_STEPS),
+expand(qc_dir + "{sample}.{step}.mean_family_depth", sample=SAMPLES, step = ALL_STEPS),
 expand(qc_dir + "{sample}.TNscope.noiseAF", sample=SAMPLES),
 expand(plot_dir + "{sample}.TNscope.AFplot.pdf", sample=SAMPLES),
-expand(table_dir + "{sample}.{varcaller}.consensusfiltered.AFtable.txt", sample=SAMPLES, varcaller=VAR_CALLER) ]
+expand(table_dir + "{sample}.{varcaller}.{step}.AFtable.txt", sample=SAMPLES, varcaller=VAR_CALLER, step= FILTERED_STEPS) ]
 
-config["rules"] = umi_call + variant_call + annotate_vcf + generate_tables + qc
+config["rules"] = umi_call + variant_call + generate_tables + annotate_vcf + qc
 
 for r in config["rules"]:
     include: Path(RULE_DIRECTORY, r).as_posix()


### PR DESCRIPTION
### This PR:

Changed: 
- sentieon_exec path in `UMIworkflow.smk` and in sentieon related umi rules (`BALSAMIC/snakemake_rules/umi/*rule`).
- changed qc_umi rules output files. Now `consensusfiltered` files are utilized instead of `consensusaligned` files.
- changes in the analysis output files (`UMIworkflow.smk`) 

Fixed: 
- Missing newline in command `bcftools query` in `generate_AF_tables.rule`
- It fixes the correct generation of output files. Previously empty AFtables are generated cause of this small bug.


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
