### PR TITLE
remove gatk3-register

### DIFF
--- a/BALSAMIC/containers/Dockerfile.latest
+++ b/BALSAMIC/containers/Dockerfile.latest
@@ -30,7 +30,6 @@ RUN mkdir -p /git_repos; \
     conda env create --file BALSAMIC/conda/varcall_py27.yaml -n varcall_py27 && \
     conda env create --file BALSAMIC/conda/varcall_py36.yaml -n varcall_py36 && \
     source activate varcall_py36 && \
-    gatk3-register BALSAMIC/assets/GenomeAnalysisTK.jar && \
     ln -s /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.7.0 /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.6 && \
     ln -s /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.7.0 /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.6.0 && \
     source deactivate && \

--- a/BALSAMIC/containers/Dockerfile.release
+++ b/BALSAMIC/containers/Dockerfile.release
@@ -30,7 +30,6 @@ RUN mkdir -p /git_repos; \
     conda env create --file BALSAMIC/conda/varcall_py27.yaml -n varcall_py27 && \
     conda env create --file BALSAMIC/conda/varcall_py36.yaml -n varcall_py36 && \
     source activate varcall_py36 && \
-    gatk3-register BALSAMIC/assets/GenomeAnalysisTK.jar && \
     ln -s /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.7.0 /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.6 && \
     ln -s /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.7.0 /usr/local/miniconda/envs/varcall_py36/lib/libreadline.so.6.0 && \
     source deactivate && \


### PR DESCRIPTION
### This PR:

Fixed:
- Removed the deprecated `gatk3-register` command

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
