### PR TITLE
Feat/umi integration

### DIFF
--- a/BALSAMIC/commands/config/case.py
+++ b/BALSAMIC/commands/config/case.py
@@ -82,7 +82,6 @@ LOG = logging.getLogger(__name__)
               show_default=True,
               is_flag=True,
               help="Enable running UMI workflow")
-
 @click.pass_context
 def case_config(context, case_id, umi, umi_trim_length, adapter_trim,
                 quality_trim, reference_config, panel_bed, background_variants,
@@ -116,7 +115,7 @@ def case_config(context, case_id, umi, umi_trim_length, adapter_trim,
             "analysis_dir": analysis_dir,
             "analysis_type": "paired" if normal else "single",
             "sequencing_type": "targeted" if panel_bed else "wgs",
-	    "umiworkflow": umiworkflow
+            "umiworkflow": umiworkflow
         },
         reference=reference_dict,
         singularity=singularity,

--- a/BALSAMIC/commands/config/case.py
+++ b/BALSAMIC/commands/config/case.py
@@ -77,10 +77,16 @@ LOG = logging.getLogger(__name__)
               required=False,
               multiple=True,
               help="Fastq files for normal sample.")
+@click.option("--umiworkflow/--no-umiworkflow",
+              default=True,
+              show_default=True,
+              is_flag=True,
+              help="Enable running UMI workflow")
+
 @click.pass_context
 def case_config(context, case_id, umi, umi_trim_length, adapter_trim,
                 quality_trim, reference_config, panel_bed, background_variants,
-                singularity, analysis_dir, tumor, normal):
+                singularity, analysis_dir, tumor, normal, umiworkflow):
 
     try:
         samples = get_sample_dict(tumor, normal)
@@ -110,6 +116,7 @@ def case_config(context, case_id, umi, umi_trim_length, adapter_trim,
             "analysis_dir": analysis_dir,
             "analysis_type": "paired" if normal else "single",
             "sequencing_type": "targeted" if panel_bed else "wgs",
+	    "umiworkflow": umiworkflow
         },
         reference=reference_dict,
         singularity=singularity,

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -52,9 +52,9 @@ else:
     # dir list
     dir_list = [bam_dir, fastqc_dir]
 
-
-    if config["analysis"]["umiworkflow"]:
+    if config["analysis"]["analysis_type"]== "single" and config["analysis"]["umiworkflow"]:
         multiqc_input.extend(expand(umi_qc_dir + "{case_name}.consensusfiltered_umi.collect_hsmetric", case_name=config["analysis"]["case_id"]))
+        
         dir_list = [bam_dir, fastqc_dir, umi_qc_dir]
 
 

--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -53,6 +53,11 @@ else:
     dir_list = [bam_dir, fastqc_dir]
 
 
+    if config["analysis"]["umiworkflow"]:
+        multiqc_input.extend(expand(umi_qc_dir + "{case_name}.consensusfiltered_umi.collect_hsmetric", case_name=config["analysis"]["case_id"]))
+        dir_list = [bam_dir, fastqc_dir, umi_qc_dir]
+
+
 rule multiqc:
     input:
         multiqc_input

--- a/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
+++ b/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
@@ -4,11 +4,11 @@
 # Generate tables for AF scatterplots
 rule bcftools_query_generatebackgroundaf_umitable:
     input:
-        vcf = vcf_dir + "SNV.somatic.{case_name}.{step}.{var_caller}.vcf.gz"
+        vcf = vcf_dir + "SNV.somatic.{case_name}.{var_caller}.vcf.gz"
     output:
-        AF = umi_qc_dir + "{case_name}.{step}.{var_caller}.AFtable.txt"
+        AF = umi_qc_dir + "{case_name}.{var_caller}.AFtable.txt"
     benchmark:
-        Path(benchmark_dir + "bcftools_query_generatebackgroundaf_umitable_{case_name}_{step}_{var_caller}.tsv").as_posix()
+        Path(benchmark_dir + "bcftools_query_generatebackgroundaf_umitable_{case_name}_{var_caller}.tsv").as_posix()
     singularity:
         singularity_image
     params:

--- a/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
+++ b/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
@@ -6,7 +6,7 @@ rule bcftools_query_generatebackgroundaf_umitable:
     input:
         vcf = vcf_dir + "SNV.somatic.{case_name}.{step}.{var_caller}.vcf.gz"
     output:
-        AF = table_dir + "{case_name}.{step}.{var_caller}.AFtable.txt"
+        AF = umi_qc_dir + "{case_name}.{step}.{var_caller}.AFtable.txt"
     benchmark:
         Path(benchmark_dir + "bcftools_query_generatebackgroundaf_umitable_{case_name}_{step}_{var_caller}.tsv").as_posix()
     singularity:

--- a/BALSAMIC/snakemake_rules/umi/qc_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/qc_umi.rule
@@ -4,11 +4,11 @@
 ## UmiAwareMarkDuplicatesWithMateCigar - umimetrics
 rule picard_umiaware:
     input:
-        bam = umi_dir + "{case_name}.{step}.bam"
+        bam = umi_dir + "{case_name}.{step}.umi.bam"
     output:
-        bam = qc_dir + "{case_name}.{step}.picard.umiaware.bam",
-        duplicates = qc_dir + "{case_name}.{step}.duplicatemetrics",
-        umimetrics = qc_dir + "{case_name}.{step}.umimetrics"
+        bam = umi_qc_dir + "{case_name}.{step}.picard.umiaware.bam",
+        duplicates = umi_qc_dir + "{case_name}.{step}.umi.duplicatemetrics",
+        umimetrics = umi_qc_dir + "{case_name}.{step}.umi.metrics"
     benchmark:
         Path(benchmark_dir + "picard_umiaware_{case_name}_{step}.tsv").as_posix()
     singularity: 
@@ -36,10 +36,10 @@ rule picard_collecthsmetrics_umi:
     input:
         fadict = (config["reference"]["reference_genome"]).replace(".fasta",".dict"),
         bed = config["panel"]["capture_kit"],
-        bam = umi_dir + "{case_name}.{step}.bam",
+        bam = umi_dir + "{case_name}.{step}.umi.bam",
         fa = config["reference"]["reference_genome"]
     output:
-        mrkdup = qc_dir + "{case_name}.{step}.collect_hsmetric_umi"
+        mrkdup = umi_qc_dir + "{case_name}.{step}.umi.collect_hsmetric"
     benchmark:
         Path(benchmark_dir + "picard_collecthsmetrics_umi_{case_name}_{step}.tsv").as_posix()
     singularity:
@@ -71,10 +71,10 @@ O={output.mrkdup};
 ## SUM(Reads in each family)/ the number of families after correction, collapsing on supporting reads.
 rule samtools_view_calculatemeanfamilydepth_umi:
     input:
-        bam = umi_dir + "{case_name}.{step}.bam"
+        bam = umi_dir + "{case_name}.{step}.umi.bam"
     output:
-        temp_fl = temp (qc_dir + "{case_name}.{step}.temp.fl"),
-        totalsum = qc_dir + "{case_name}.{step}.mean_family_depth"
+        temp_fl = temp (umi_qc_dir + "{case_name}.{step}.umi.temp.fl"),
+        totalsum = umi_qc_dir + "{case_name}.{step}.umi.mean_family_depth"
     benchmark:
         Path(benchmark_dir + "samtools_view_calculatemeanfamilydepth_umi_{case_name}_{step}.tsv").as_posix()
     singularity:
@@ -112,9 +112,9 @@ rule bcftools_query_calculatenoiseAF_umi:
         umiextract = vcf_dir + "SNV.somatic.{case_name}.consensusaligned.TNscope.umi.vcf.gz",
         consensuscall = vcf_dir + "SNV.somatic.{case_name}.consensusfiltered.TNscope.umi.vcf.gz"
     output:
-        umiextractAF = temp (qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt"),
-        consensuscallAF = temp (qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"),
-        noiseAF = qc_dir + "{case_name}.TNscope.umi.noiseAF"
+        umiextractAF = temp (umi_qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt"),
+        consensuscallAF = temp (umi_qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"),
+        noiseAF = umi_qc_dir + "{case_name}.TNscope.umi.noiseAF"
     benchmark:
         Path(benchmark_dir + "bcftools_query_calculatenoiseAF_umi_{case_name}.tsv").as_posix()
     singularity:
@@ -153,10 +153,10 @@ END {{print(\"NoiseAF: \"(sum1/f1_nr)/(sum2/(NR-f1_nr)))}}' \
 # Plot the TNscope calculated AFs before and after consensuscall
 rule seaborn_densityplot_umi:
     input:
-        table1 = qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt",
-        table2 = qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"
+        table1 = umi_qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt",
+        table2 = umi_qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"
     output:
-        AF_plot = plot_dir + "{case_name}.TNscope.umi.AFplot.pdf"
+        AF_plot = umi_qc_dir  + "{case_name}.TNscope.umi.AFplot.pdf"
     benchmark:
         Path(benchmark_dir + "seaborn_densityplot_umi_{case_name}.tsv").as_posix()
     params:

--- a/BALSAMIC/snakemake_rules/umi/qc_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/qc_umi.rule
@@ -7,8 +7,8 @@ rule picard_umiaware:
         bam = umi_dir + "{case_name}.{step}.umi.bam"
     output:
         bam = umi_qc_dir + "{case_name}.{step}.picard.umiaware.bam",
-        duplicates = umi_qc_dir + "{case_name}.{step}.umi.duplicatemetrics",
-        umimetrics = umi_qc_dir + "{case_name}.{step}.umi.metrics"
+        duplicates = umi_qc_dir + "{case_name}.{step}_umi.duplicatemetrics",
+        umimetrics = umi_qc_dir + "{case_name}.{step}_umi.metrics"
     benchmark:
         Path(benchmark_dir + "picard_umiaware_{case_name}_{step}.tsv").as_posix()
     singularity: 
@@ -39,7 +39,7 @@ rule picard_collecthsmetrics_umi:
         bam = umi_dir + "{case_name}.{step}.umi.bam",
         fa = config["reference"]["reference_genome"]
     output:
-        mrkdup = umi_qc_dir + "{case_name}.{step}.umi.collect_hsmetric"
+        mrkdup = umi_qc_dir + "{case_name}.{step}_umi.collect_hsmetric"
     benchmark:
         Path(benchmark_dir + "picard_collecthsmetrics_umi_{case_name}_{step}.tsv").as_posix()
     singularity:
@@ -74,7 +74,7 @@ rule samtools_view_calculatemeanfamilydepth_umi:
         bam = umi_dir + "{case_name}.{step}.umi.bam"
     output:
         temp_fl = temp (umi_qc_dir + "{case_name}.{step}.umi.temp.fl"),
-        totalsum = umi_qc_dir + "{case_name}.{step}.umi.mean_family_depth"
+        totalsum = umi_qc_dir + "{case_name}.{step}_umi.mean_family_depth"
     benchmark:
         Path(benchmark_dir + "samtools_view_calculatemeanfamilydepth_umi_{case_name}_{step}.tsv").as_posix()
     singularity:
@@ -109,12 +109,12 @@ END{{printf(\"{params.sample_id}_meandepth: \"sum/NR)}}' \
 ## Noise AF = TotalAF_with_UMI/TotalAF_without_UMI - considering TNscope values
 rule bcftools_query_calculatenoiseAF_umi:
     input:
-        umiextract = vcf_dir + "SNV.somatic.{case_name}.consensusaligned.TNscope.umi.vcf.gz",
-        consensuscall = vcf_dir + "SNV.somatic.{case_name}.consensusfiltered.TNscope.umi.vcf.gz"
+        umiextract = vcf_dir + "SNV.somatic.{case_name}.TNscope_consensusaligned_umi.vcf.gz",
+        consensuscall = vcf_dir + "SNV.somatic.{case_name}.TNscope_consensusfiltered_umi.vcf.gz"
     output:
-        umiextractAF = temp (umi_qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt"),
-        consensuscallAF = temp (umi_qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"),
-        noiseAF = umi_qc_dir + "{case_name}.TNscope.umi.noiseAF"
+        umiextractAF = temp (umi_qc_dir + "{case_name}.TNscope_consensusaligned_umi.AF.txt"),
+        consensuscallAF = temp (umi_qc_dir + "{case_name}.TNscope_consensusfiltered_umi.AF.txt"),
+        noiseAF = umi_qc_dir + "{case_name}.TNscope_umi.noiseAF"
     benchmark:
         Path(benchmark_dir + "bcftools_query_calculatenoiseAF_umi_{case_name}.tsv").as_posix()
     singularity:
@@ -153,10 +153,10 @@ END {{print(\"NoiseAF: \"(sum1/f1_nr)/(sum2/(NR-f1_nr)))}}' \
 # Plot the TNscope calculated AFs before and after consensuscall
 rule seaborn_densityplot_umi:
     input:
-        table1 = umi_qc_dir + "{case_name}.TNscope.umi.consensusaligned.AF.txt",
-        table2 = umi_qc_dir + "{case_name}.TNscope.umi.consensusfiltered.AF.txt"
+        table1 = umi_qc_dir + "{case_name}.TNscope_consensusaligned_umi.AF.txt",
+        table2 = umi_qc_dir + "{case_name}.TNscope_consensusfiltered_umi.AF.txt"
     output:
-        AF_plot = umi_qc_dir  + "{case_name}.TNscope.umi.AFplot.pdf"
+        AF_plot = umi_qc_dir  + "{case_name}.TNscope_umi.AFplot.pdf"
     benchmark:
         Path(benchmark_dir + "seaborn_densityplot_umi_{case_name}.tsv").as_posix()
     params:

--- a/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
@@ -4,9 +4,9 @@
 # UMI-consensus calling
 rule sentieon_consensuscall_umi:
     input:
-        sam_consensus = umi_dir + "{case_name}.umialign.bam"
+        sam_consensus = umi_dir + "{case_name}.align.umi.bam"
     output:
-        fastq_consensus = temp(umi_dir + "{case_name}.consensuscall.fastq.gz")
+        fastq_consensus = temp(umi_dir + "{case_name}.consensuscall.umi.fastq.gz")
     benchmark:
         Path(benchmark_dir + "sentieon_consensuscall_umi_{case_name}.tsv").as_posix()
     params:
@@ -34,9 +34,9 @@ rule sentieon_consensuscall_umi:
 rule sentieon_bwa_umiconsensus:
     input:
         ref_fa = config["reference"]["reference_genome"],
-        fq_consensus = umi_dir + "{case_name}.consensuscall.fastq.gz"
+        fq_consensus = umi_dir + "{case_name}.consensuscall.umi.fastq.gz"
     output:
-        align_consensus = umi_dir + "{case_name}.consensusaligned.bam"
+        align_consensus = umi_dir + "{case_name}.consensusaligned.umi.bam"
     benchmark:
         Path(benchmark_dir + "sentieon_bwa_umiconsensus_{case_name}.tsv").as_posix()
     params:
@@ -67,9 +67,9 @@ rule sentieon_bwa_umiconsensus:
 # Filter consensus called reads based on 'XZ' filtering
 rule sentieon_consensusfilter_umi:
     input:
-        umi_dir + "{case_name}.consensusaligned.bam"
+        umi_dir + "{case_name}.consensusaligned.umi.bam"
     output:
-        umi_dir + "{case_name}.consensusfiltered.bam"
+        umi_dir + "{case_name}.consensusfiltered.umi.bam"
     benchmark:
         Path(benchmark_dir + "sentieon_consensusfilter_umi_{case_name}.tsv").as_posix()
     singularity:

--- a/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
@@ -32,7 +32,7 @@ rule sentieon_bwa_umiextract:
         ref_fa = config["reference"]["reference_genome"],
         fastq_umi = expand(umi_dir + "{mysample}.umiextract.fastq.gz", mysample=get_sample_type(config["samples"],"tumor"))
     output:
-        align_umi = temp(umi_dir + "{case_name}.umialign.bam")
+        align_umi = temp(umi_dir + "{case_name}.align.umi.bam")
     benchmark:
         Path(benchmark_dir + "sentieon_bwa_umiextract_{case_name}.tsv").as_posix()
     params:

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -9,8 +9,8 @@ rule sentieon_tnscope_umi:
         bed = config["panel"]["capture_kit"],
         dbsnp = config["reference"]["dbsnp"]
     output:
-        vcf = vcf_dir +  "SNV.somatic.{case_name}.{step}.TNscope.umi.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic.{case_name}.{step}.TNscope.umi.sample_name_map"
+        vcf = vcf_dir +  "SNV.somatic.{case_name}.TNscope_{step}_umi.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic.{case_name}.TNscope_{step}_umi.sample_name_map"
     benchmark:
         Path(benchmark_dir + "sentieon_tnscope_umi_{case_name}.{step}.tsv").as_posix()
     params:

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -4,7 +4,7 @@
 # Variant-calling using TNscope
 rule sentieon_tnscope_umi:
     input:
-        bam = umi_dir + "{case_name}.{step}.bam",
+        bam = umi_dir + "{case_name}.{step}.umi.bam",
         ref_fa = config["reference"]["reference_genome"],
         bed = config["panel"]["capture_kit"],
         dbsnp = config["reference"]["dbsnp"]
@@ -12,14 +12,15 @@ rule sentieon_tnscope_umi:
         vcf = vcf_dir +  "SNV.somatic.{case_name}.{step}.TNscope.umi.vcf.gz",
         namemap = vcf_dir + "SNV.somatic.{case_name}.{step}.TNscope.umi.sample_name_map"
     benchmark:
-        Path(benchmark_dir + "sentieon_tnscope_{case_name}.{step}.tsv").as_posix()
+        Path(benchmark_dir + "sentieon_tnscope_umi_{case_name}.{step}.tsv").as_posix()
     params:
         sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         tumor_af = paramsumi.common.filter_tumor_af,
         algo = paramsumi.tnscope.algo,
         disable_detect = paramsumi.tnscope.disable_detect,
-        tumor_lod = config["tumorlod"], #paramsumi.tnscope.min_tumorLOD,
+        #tumor_lod = config["tumorlod"], #paramsumi.tnscope.min_tumorLOD,
+        tumor_lod = paramsumi.tnscope.min_tumorLOD,
         error_rate = paramsumi.tnscope.error_rate,
         prune_factor = paramsumi.tnscope.prunefactor,
         tumor = get_sample_type(config["samples"], "tumor"),

--- a/BALSAMIC/snakemake_rules/umi/varcall_vardict.rule
+++ b/BALSAMIC/snakemake_rules/umi/varcall_vardict.rule
@@ -8,8 +8,8 @@ rule vardict_umi:
         ref_fa = config["reference"]["reference_genome"],
         bed = config["panel"]["capture_kit"]
     output:
-        vardict = vcf_dir + "SNV.somatic.{case_name}.{step}.vardict.umi.vcf.gz",
-        namemap = vcf_dir + "SNV.somatic.{case_name}.{step}.vardict.umi.sample_name_map",
+        vardict = vcf_dir + "SNV.somatic.{case_name}.vardict_{step}_umi.vcf.gz",
+        namemap = vcf_dir + "SNV.somatic.{case_name}.vardict_{step}_umi.sample_name_map",
     benchmark:
         Path(benchmark_dir + "vardict_umi_{case_name}_{step}.tsv").as_posix()
     singularity: 

--- a/BALSAMIC/snakemake_rules/umi/varcall_vardict.rule
+++ b/BALSAMIC/snakemake_rules/umi/varcall_vardict.rule
@@ -4,14 +4,14 @@
 # Variant-calling using vardict
 rule vardict_umi:
     input:
-        bam = umi_dir + "{case_name}.{step}.bam",
+        bam = umi_dir + "{case_name}.{step}.umi.bam",
         ref_fa = config["reference"]["reference_genome"],
         bed = config["panel"]["capture_kit"]
     output:
         vardict = vcf_dir + "SNV.somatic.{case_name}.{step}.vardict.umi.vcf.gz",
         namemap = vcf_dir + "SNV.somatic.{case_name}.{step}.vardict.umi.sample_name_map",
     benchmark:
-        Path(benchmark_dir + "vardict_{case_name}_{step}.tsv").as_posix()
+        Path(benchmark_dir + "vardict_umi_{case_name}_{step}.tsv").as_posix()
     singularity: 
         singularity_image
     params:

--- a/BALSAMIC/utils/constants.py
+++ b/BALSAMIC/utils/constants.py
@@ -39,10 +39,22 @@ SENTIEON_TNSCOPE = Path(
 MUTATION_CLASS = ["somatic", "germline"]
 MUTATION_TYPE = ["SNV", "SV", "CNV"]
 ANALYSIS_TYPES = ["paired", "single", "umi", "qc"]
-WORKFLOW_SOLUTION = ["BALSAMIC", "Sentieon", "DRAGEN"]
+WORKFLOW_SOLUTION = ["BALSAMIC", "Sentieon", "DRAGEN", "Sentieon_umi"]
 
 # Configuration of VCF settings
 VCF_DICT = {
+    "TNscope_consensusaligned_umi": {
+        "mutation": "somatic",
+	"type": "SNV",
+	"analysis_type": "single",
+	"workflow_solution": "Sentieon_umi"
+    },
+    "TNscope_consensusaligned_umi" : {
+	"mutation": "somatic",
+        "type": "SNV",
+        "analysis_type": "single",
+        "workflow_solution": "Sentieon_umi"
+    },
     "tnsnv": {
         "mutation": "somatic",
         "type": "SNV",

--- a/BALSAMIC/utils/constants.py
+++ b/BALSAMIC/utils/constants.py
@@ -46,14 +46,14 @@ VCF_DICT = {
     "TNscope_consensusaligned_umi": {
         "mutation": "somatic",
 	"type": "SNV",
-	"analysis_type": "single",
-	"workflow_solution": "Sentieon_umi"
+	"analysis_type": ["single"],
+	"workflow_solution": ["Sentieon_umi"]
     },
-    "TNscope_consensusaligned_umi" : {
+    "TNscope_consensusfiltered_umi": {
 	"mutation": "somatic",
         "type": "SNV",
-        "analysis_type": "single",
-        "workflow_solution": "Sentieon_umi"
+        "analysis_type": ["single"],
+        "workflow_solution": ["Sentieon_umi"]
     },
     "tnsnv": {
         "mutation": "somatic",

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -154,6 +154,8 @@ class VCFModel(BaseModel):
     tnhaplotyper: VarcallerAttribute
     manta_germline: VarcallerAttribute
     haplotypecaller: VarcallerAttribute
+    TNscope_consensusaligned_umi: VarcallerAttribute
+    TNscope_consensusfiltered_umi: VarcallerAttribute
 
 
 class AnalysisModel(BaseModel):

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -169,6 +169,7 @@ class AnalysisModel(BaseModel):
             targeted : if capture kit was used to enrich specific genomic regions
             wgs : if whole genome sequencing was performed
         analysis_dir : Field(required); existing path where to save files
+	umiworkflow : Field(bool); whether UMI workflow to run parallely 
 
         fastq_path : Field(optional); Path where fastq files will be stored
         script : Field(optional); Path where snakemake scripts will be stored
@@ -198,6 +199,7 @@ class AnalysisModel(BaseModel):
     dag: Optional[FilePath]
     BALSAMIC_version: str = balsamic_version
     config_creation_date: Optional[str]
+    umiworkflow: bool = True
 
     class Config:
         validate_all = True

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -169,7 +169,7 @@ class AnalysisModel(BaseModel):
             targeted : if capture kit was used to enrich specific genomic regions
             wgs : if whole genome sequencing was performed
         analysis_dir : Field(required); existing path where to save files
-	umiworkflow : Field(bool); whether UMI workflow to run parallely 
+        umiworkflow : Field(bool); whether UMI workflow to run parallely 
 
         fastq_path : Field(optional); Path where fastq files will be stored
         script : Field(optional); Path where snakemake scripts will be stored

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -340,6 +340,7 @@ class BalsamicConfigModel(BaseModel):
         background_variants: Field(Path(optional)); path to BACKGROUND VARIANTS for UMI
         conda_env_yaml : Field(Path(CONVA_ENV_YAML)); path where Balsamic configs can be found
         rule_directory : Field(Path(RULE_DIRECTORY)); path where snakemake rules can be found
+	umiworkflow : Field(bool); whether UMI workflow to run parallely with balsamic workflow
 
     """
 
@@ -353,6 +354,7 @@ class BalsamicConfigModel(BaseModel):
     conda_env_yaml: FilePath = CONDA_ENV_YAML
     bioinfo_tools: Optional[BioinfoToolsModel]
     panel: Optional[PanelModel]
+    umiworkflow: bool = True
 
     @validator("reference")
     def abspath_as_str(cls, value):

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -63,22 +63,20 @@ paramsumi = UMIworkflowConfig.parse_obj(umiworkflow_params)
 # Define wildcards
 SAMPLES = config["samples"]
 CASE_NAME = config["analysis"]["case_id"]
-VAR_CALLER = ["TNscope.umi","vardict.umi"]
+VAR_CALLER = ["TNscope","vardict"]
 ALL_STEPS = ["consensusaligned","consensusfiltered", "umialign"]
 FILTERED_STEPS = ["consensusaligned","consensusfiltered"]
-NEW_CASE_NAME = expand("{case_nm}.{step}", case_nm = CASE_NAME, step=FILTERED_STEPS)
+EXTN_NAME = expand("{var_caller}_{step}_umi", var_caller = ["TNscope","vardict"], step=FILTERED_STEPS)
 
 # Define outputs
-analysis_output = [ expand(vcf_dir + "SNV.somatic.{case_name}.{step}.{var_caller}.vcf.gz", case_name=CASE_NAME, step =FILTERED_STEPS, var_caller=VAR_CALLER), 
-expand(vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.{filters}.vcf.gz", var_type= "SNV", case_name=NEW_CASE_NAME, var_caller= VAR_CALLER, filters=["all", "pass"]),
-expand(umi_qc_dir + "{case_name}.{step}.umi.metrics", case_name=CASE_NAME, step=FILTERED_STEPS),
-expand(umi_qc_dir + "{case_name}.{step}.umi.collect_hsmetric", case_name=CASE_NAME, step=FILTERED_STEPS),
-expand(umi_qc_dir + "{case_name}.{step}.umi.mean_family_depth", case_name=CASE_NAME, step = FILTERED_STEPS),
-expand(umi_qc_dir + "{case_name}.{var_caller}.noiseAF", case_name=CASE_NAME, var_caller=['TNscope.umi']),
-expand(umi_qc_dir + "{case_name}.{var_caller}.AFplot.pdf", case_name=CASE_NAME, var_caller=['TNscope.umi']),
-expand(umi_qc_dir + "{case_name}.{step}.{varcaller}.AFtable.txt", case_name=CASE_NAME, varcaller=VAR_CALLER, step= FILTERED_STEPS) ] 
+analysis_output = [ expand(vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.{filters}.vcf.gz", var_type= "SNV", case_name=CASE_NAME, var_caller=EXTN_NAME, filters=["all", "pass"]),
+expand(umi_qc_dir + "{case_name}.{step}_umi.{metric}", case_name=CASE_NAME, step=FILTERED_STEPS, metric = ["metrics","collect_hsmetric", "mean_family_depth"]),
+expand(umi_qc_dir + "{case_name}.{var_caller}_umi.noiseAF", case_name=CASE_NAME, var_caller=["TNscope"]),
+expand(umi_qc_dir + "{case_name}.{var_caller}_umi.AFplot.pdf", case_name=CASE_NAME, var_caller=["TNscope"]),
+expand(umi_qc_dir + "{case_name}.{var_caller}.AFtable.txt", case_name=CASE_NAME, var_caller=EXTN_NAME)
+]
 
-config["rules"] = umi_call + variant_call + generate_tables + annotate_vcf + qc
+config["rules"] = umi_call + variant_call +  annotate_vcf + qc + generate_tables
 
 for r in config["rules"]:
     include: Path(RULE_DIRECTORY, r).as_posix()

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -19,9 +19,7 @@ benchmark_dir = config["analysis"]["benchmark"]
 umi_dir = get_result_dir(config) + "/umi/"
 vcf_dir = get_result_dir(config) + "/vcf/"
 vep_dir = get_result_dir(config) + "/vep/"
-table_dir = get_result_dir(config) + "/tables/"
-plot_dir = get_result_dir(config) + "/plots/"
-qc_dir = get_result_dir(config) + "/qc/"
+umi_qc_dir = get_result_dir(config) + "/qc/"
 
 singularity_image = config["singularity"]["image"]
 
@@ -73,12 +71,12 @@ NEW_CASE_NAME = expand("{case_nm}.{step}", case_nm = CASE_NAME, step=FILTERED_ST
 # Define outputs
 analysis_output = [ expand(vcf_dir + "SNV.somatic.{case_name}.{step}.{var_caller}.vcf.gz", case_name=CASE_NAME, step =FILTERED_STEPS, var_caller=VAR_CALLER), 
 expand(vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.{filters}.vcf.gz", var_type= "SNV", case_name=NEW_CASE_NAME, var_caller= VAR_CALLER, filters=["all", "pass"]),
-expand(qc_dir + "{case_name}.{step}.umimetrics", case_name=CASE_NAME, step=FILTERED_STEPS),
-expand(qc_dir + "{case_name}.{step}.collect_hsmetric_umi", case_name=CASE_NAME, step=FILTERED_STEPS),
-expand(qc_dir + "{case_name}.{step}.mean_family_depth", case_name=CASE_NAME, step = FILTERED_STEPS),
-expand(qc_dir + "{case_name}.{var_caller}.noiseAF", case_name=CASE_NAME, var_caller=['TNscope.umi']),
-expand(plot_dir + "{case_name}.{var_caller}.AFplot.pdf", case_name=CASE_NAME, var_caller=['TNscope.umi']),
-expand(table_dir + "{case_name}.{step}.{varcaller}.AFtable.txt", case_name=CASE_NAME, varcaller=VAR_CALLER, step= FILTERED_STEPS) ] 
+expand(umi_qc_dir + "{case_name}.{step}.umi.metrics", case_name=CASE_NAME, step=FILTERED_STEPS),
+expand(umi_qc_dir + "{case_name}.{step}.umi.collect_hsmetric", case_name=CASE_NAME, step=FILTERED_STEPS),
+expand(umi_qc_dir + "{case_name}.{step}.umi.mean_family_depth", case_name=CASE_NAME, step = FILTERED_STEPS),
+expand(umi_qc_dir + "{case_name}.{var_caller}.noiseAF", case_name=CASE_NAME, var_caller=['TNscope.umi']),
+expand(umi_qc_dir + "{case_name}.{var_caller}.AFplot.pdf", case_name=CASE_NAME, var_caller=['TNscope.umi']),
+expand(umi_qc_dir + "{case_name}.{step}.{varcaller}.AFtable.txt", case_name=CASE_NAME, varcaller=VAR_CALLER, step= FILTERED_STEPS) ] 
 
 config["rules"] = umi_call + variant_call + generate_tables + annotate_vcf + qc
 

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -102,6 +102,7 @@ qc_rules = [
     "snakemake_rules/quality_control/fastp.rule",
     "snakemake_rules/quality_control/fastqc.rule",
     "snakemake_rules/quality_control/multiqc.rule",
+    "snakemake_rules/umi/qc_umi.rule"
 ]
 if config["analysis"]["sequencing_type"] == "wgs":
     qc_rules.extend([
@@ -246,14 +247,13 @@ if config['analysis']['analysis_type'] == "single" and config["analysis"]["seque
     analysis_specific_results.extend([expand(vep_dir + "{vcf}.all.filtered.vcf.gz",
                                             vcf=get_vcf(config, ["vardict"], [config["analysis"]["case_id"]]))])
     if config["analysis"]["umiworkflow"]:
-        config["rules"] = config["rules"] + umiqc_rules
+        config["rules"] = config["rules"] #+ umiqc_rules
         analysis_specific_results.extend([expand(vep_dir + "{vcf}.{filters}.vcf.gz",
                                           vcf=get_vcf(config, somatic_caller_snv_umi, [config["analysis"]["case_id"]]), filters=["all","pass"]), 
-                                      expand(umi_qc_dir + "{case_name}.{step}_umi.{metric}",
+                                      expand(umi_qc_dir + "{case_name}.{step}_umi.mean_family_depth",
                                           case_name = config["analysis"]["case_id"],
-                                          step=["consensusaligned","consensusfiltered"],
-                                          metric = ["collect_hsmetric", "mean_family_depth"]),
-                                     expand(umi_qc_dir + "{case_name}.{var_caller}_umi.{metric}",
+                                          step=["consensusaligned","consensusfiltered"]),
+                                      expand(umi_qc_dir + "{case_name}.{var_caller}_umi.{metric}",
                                           case_name = config["analysis"]["case_id"],
                                           var_caller = ["TNscope"],
                                           metric = ["noiseAF", "AFplot.pdf"])])

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -102,8 +102,9 @@ qc_rules = [
     "snakemake_rules/quality_control/fastp.rule",
     "snakemake_rules/quality_control/fastqc.rule",
     "snakemake_rules/quality_control/multiqc.rule",
-    "snakemake_rules/umi/qc_umi.rule"
 ]
+
+
 if config["analysis"]["sequencing_type"] == "wgs":
     qc_rules.extend([
         "snakemake_rules/quality_control/sentieon_qc_metrics.rule",
@@ -124,6 +125,7 @@ else:
         "snakemake_rules/umi/sentieon_umiextract.rule",
         "snakemake_rules/umi/sentieon_consensuscall.rule"
     ]
+
 
 annotation_rules = [ "snakemake_rules/annotation/vep.rule" ]
 
@@ -247,7 +249,6 @@ if config['analysis']['analysis_type'] == "single" and config["analysis"]["seque
     analysis_specific_results.extend([expand(vep_dir + "{vcf}.all.filtered.vcf.gz",
                                             vcf=get_vcf(config, ["vardict"], [config["analysis"]["case_id"]]))])
     if config["analysis"]["umiworkflow"]:
-        config["rules"] = config["rules"] #+ umiqc_rules
         analysis_specific_results.extend([expand(vep_dir + "{vcf}.{filters}.vcf.gz",
                                           vcf=get_vcf(config, somatic_caller_snv_umi, [config["analysis"]["case_id"]]), filters=["all","pass"]), 
                                       expand(umi_qc_dir + "{case_name}.{step}_umi.mean_family_depth",
@@ -257,8 +258,9 @@ if config['analysis']['analysis_type'] == "single" and config["analysis"]["seque
                                           case_name = config["analysis"]["case_id"],
                                           var_caller = ["TNscope"],
                                           metric = ["noiseAF", "AFplot.pdf"])])
+        config["rules"] = config["rules"] + umiqc_rules
         if "background_variants" in config:
-            analysis_specific_results.extend([expand(umi_qc_dir + "{case_name}.{var_caller}.AFtable.txt",                                           case_name = config["analysis"]["case_id"],
+            analysis_specific_results.extend([expand(umi_qc_dir + "{case_name}.{var_caller}.AFtable.txt", case_name = config["analysis"]["case_id"],
                                           var_caller = expand("{var_caller}_{step}_umi",
                                           var_caller =["TNscope"],
                                           step = ["consensusaligned","consensusfiltered"]))])

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -313,8 +313,7 @@ if 'delivery' in config:
 
 rule all:
     input:
-        #quality_control_results + analysis_specific_results
-        analysis_specific_results
+        quality_control_results + analysis_specific_results
     output:
         os.path.join(get_result_dir(config), "analysis_finish")
     shell:

--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -248,7 +248,7 @@ if config['analysis']['analysis_type'] == "single" and config["analysis"]["seque
     if config["analysis"]["umiworkflow"]:
         config["rules"] = config["rules"] + umiqc_rules
         analysis_specific_results.extend([expand(vep_dir + "{vcf}.{filters}.vcf.gz",
-                                          vcf=get_vcf(config, somatic_caller_snv_umi, [config["analysis"]["case_id"]])), 
+                                          vcf=get_vcf(config, somatic_caller_snv_umi, [config["analysis"]["case_id"]]), filters=["all","pass"]), 
                                       expand(umi_qc_dir + "{case_name}.{step}_umi.{metric}",
                                           case_name = config["analysis"]["case_id"],
                                           step=["consensusaligned","consensusfiltered"],
@@ -262,7 +262,7 @@ if config['analysis']['analysis_type'] == "single" and config["analysis"]["seque
                                           var_caller = expand("{var_caller}_{step}_umi",
                                           var_caller =["TNscope"],
                                           step = ["consensusaligned","consensusfiltered"]))])
-            config["rules"] = config["rules"] + umiqc_rules + generatetable_umi_rules
+            config["rules"] = config["rules"] + generatetable_umi_rules
 
 
 if config["analysis"]["sequencing_type"] == "wgs" and config['analysis']['analysis_type'] == "single":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,8 +365,8 @@ def tumor_only_wgs_config(tmp_path_factory, sample_fastq, analysis_dir,
 @pytest.fixture(scope="session")
 def tumor_only_umi_config(tmpdir_factory, sample_fastq, singularity_container,
                           analysis_dir, reference_json, panel_bed_file,
-                          background_variant_file, sentieon_license,
-                          sentieon_install_dir):
+                          background_variant_file, umiworkflow,
+                          sentieon_license, sentieon_install_dir):
     """
     invokes balsamic config sample -t xxx to create sample config
     for tumor only with background variant file for umi workflow
@@ -383,22 +383,11 @@ def tumor_only_umi_config(tmpdir_factory, sample_fastq, singularity_container,
         runner.invoke(
             cli,
             [
-                "config",
-                "case",
-                "-p",
-                panel_bed_file,
-                "--background-variants",
-                background_variant_file,
-                "-t",
-                tumor,
-                "--case-id",
-                case_id,
-                "--analysis-dir",
-                analysis_dir,
-                "--singularity",
-                singularity_container,
-                "--reference-config",
-                reference_json,
+                "config", "case", "-p", panel_bed_file,
+                "--background-variants", background_variant_file, "-t", tumor,
+                "--case-id", case_id, "--analysis-dir", analysis_dir,
+                "--singularity", singularity_container, "--reference-config",
+                reference_json, "--umiworkflow"
             ],
         )
 
@@ -422,26 +411,18 @@ def sample_config():
             "umi_trim_length": "5",
         },
         "analysis": {
-            "case_id":
-            "id1",
-            "analysis_type":
-            "paired",
-            "analysis_dir":
-            "tests/test_data/",
-            "fastq_path":
-            "tests/test_data/id1/fastq/",
-            "script":
-            "tests/test_data/id1/scripts/",
-            "log":
-            "tests/test_data/id1/logs/",
-            "result":
-            "tests/test_data/id1/analysis/",
-            "config_creation_date":
-            "yyyy-mm-dd xx",
-            "BALSAMIC_version":
-            "2.9.8",
+            "case_id": "id1",
+            "analysis_type": "paired",
+            "analysis_dir": "tests/test_data/",
+            "fastq_path": "tests/test_data/id1/fastq/",
+            "script": "tests/test_data/id1/scripts/",
+            "log": "tests/test_data/id1/logs/",
+            "result": "tests/test_data/id1/analysis/",
+            "config_creation_date": "yyyy-mm-dd xx",
+            "BALSAMIC_version": "2.9.8",
             "dag":
             "tests/test_data/id1/id1_analysis.json_BALSAMIC_2.9.8_graph.pdf",
+            "umiworkflow": "true"
         },
         "vcf": {
             "manta": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,7 +365,7 @@ def tumor_only_wgs_config(tmp_path_factory, sample_fastq, analysis_dir,
 @pytest.fixture(scope="session")
 def tumor_only_umi_config(tmpdir_factory, sample_fastq, singularity_container,
                           analysis_dir, reference_json, panel_bed_file,
-                          background_variant_file, umiworkflow,
+                          background_variant_file, 
                           sentieon_license, sentieon_install_dir):
     """
     invokes balsamic config sample -t xxx to create sample config
@@ -387,7 +387,7 @@ def tumor_only_umi_config(tmpdir_factory, sample_fastq, singularity_container,
                 "--background-variants", background_variant_file, "-t", tumor,
                 "--case-id", case_id, "--analysis-dir", analysis_dir,
                 "--singularity", singularity_container, "--reference-config",
-                reference_json, "--umiworkflow"
+                reference_json
             ],
         )
 


### PR DESCRIPTION
## Background:
So far, the developed UMI workflow was run independently with balsamic cli with the option `--analysis-type umi` (#359 )
But the main goal is to run UMI workflow as an internal part of the main balsamic workflow for `tumor-only` and `targeted panel` cases. 

### This PR:
The option  ```--umiworkflow/--no-umi workflow``` is added to the config file, which commands the main balsamic workflow to execute umi workflow for `tumor-only `cases and `panel` data (default option). The output results `vcf` and `vep` folders consist of extra files with `*.umi*` tag

**Testing:** 
**case1:** Run balsamic and umi workflow for` tumoronly` and `panel` data 
```  
step1:
balsamic config case \
    -t ${_tumor_fastq} \
    ${_normal_option} \
    --case-id ${_case_name} \
    --analysis-dir ${_analysis_dir} \
    -r ${_reference} \
    ${_panel_option} \
    --singularity ${_singularity} \
    --background-variants ${_bg_variants} \
    --umiworkflow

step 2:
balsamic run analysis -s ${_analysis_config} -c ${_cluster_config} --account development ${_run_analysis}
```
<img width="548" alt="tumoronly_panel_withumi_n2" src="https://user-images.githubusercontent.com/6302819/101065798-e1d27f00-3595-11eb-8aa5-97f5d43faff1.png">

**case2: ** Run **only balsamic** for` tumoronly` and `panel` data 

```  
step1:
balsamic config case \
    -t ${_tumor_fastq} \
    ${_normal_option} \
    --case-id ${_case_name} \
    --analysis-dir ${_analysis_dir} \
    -r ${_reference} \
    ${_panel_option} \
    --singularity ${_singularity} \
    --no-umiworkflow

step 2:
balsamic run analysis -s ${_analysis_config} -c ${_cluster_config} --account development ${_run_analysis}
```

<img width="737" alt="tumoonly_panel_noumi_n2" src="https://user-images.githubusercontent.com/6302819/101011034-c39f5b80-3562-11eb-91f9-74278badf9ba.png">


VEP results folder with `*.umi*` vcf files
<img width="457" alt="vep_results" src="https://user-images.githubusercontent.com/6302819/100467473-c7e6f700-30d2-11eb-9be6-1c3b190fed05.png">




### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
