### PR TITLE
readlink command fix according to container

### DIFF
--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -25,7 +25,7 @@ rule vep_somatic:
   shell:
     """
 source activate {params.conda};
-vep_path=$(dirname $(readlink -e $(which vep)));
+vep_path=$(dirname $(readlink -f $(which vep)));
 tmpvcf={params.tmpvcf};
 export PERL5LIB=;
 vcfanno --base-path {params.ref_path} {params.vcfanno_toml} {input.vcf} \
@@ -101,7 +101,7 @@ rule vep_germline:
   shell:
       """
 source activate {params.conda};
-vep_path=$(dirname $(readlink -e $(which vep)));
+vep_path=$(dirname $(readlink -f $(which vep)));
 export PERL5LIB=;
 vep \
 --dir $vep_path \

--- a/BALSAMIC/snakemake_rules/quality_control/GATK.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/GATK.rule
@@ -76,7 +76,7 @@ rule PreparePopVCF:
     benchmark_dir + "PreparePopVCF_" + "tumor_prepare_pop_vcf.tsv"
   shell:
     "source activate {params.conda}; "
-    "readlink -e {input.bam}; "
+    "readlink -f {input.bam}; "
     "bcftools annotate "
         "-x {params.anno_str1}{params.popcode}_AF "
         "{input.ref1kg} "

--- a/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/split_bed.rule
@@ -32,4 +32,4 @@ rule split_bed_by_chrom:
             " > {params.split_bed_dir}$c.{params.origin_bed}; "
         "done; "
         "unset chromlist; "
-        "readlink -e {input.bam}; "
+        "readlink -f {input.bam}; "


### PR DESCRIPTION
### This PR:

Fixed:
- Linux `readlink` command in `vep_germline`, `vep_somatic`, `split_bed`, and `GATK_popVCF`

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
