### PR TITLE
Hotfix, reduce MQ filter cutoff to 40

### DIFF
--- a/BALSAMIC/utils/constants.py
+++ b/BALSAMIC/utils/constants.py
@@ -116,7 +116,7 @@ VARDICT_SETTINGS = {
         "field": "INFO",
     },
     "MQ": {
-        "tag_value": 50,
+        "tag_value": 40,
         "filter_name": "balsamic_low_mq",
         "field": "INFO"
     },
@@ -126,7 +126,7 @@ VARDICT_SETTINGS = {
         "field": "INFO"
     },
     "AF_min": {
-        "tag_value": 0.02,
+        "tag_value": 0.01,
         "filter_name": "balsamic_low_af",
         "field": "INFO"
     },


### PR DESCRIPTION
### This PR:

Fixed:
- Reduces MQ cutoff from 50 to 40 to only remove obvious artifacts.
- Reduces AF cutoff from 0.02 to 0.01

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
