### PR TITLE
bump up bcftools

### DIFF
--- a/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
+++ b/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.6
   - bcftools=1.11
   - tabix=0.2.6
-  - samtools=1.10
+  - samtools=1.11
   - gatk=3.8
   - vardict=2019.06.04=pl526_0
   - vardict-java=1.7

--- a/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
+++ b/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python=3.6
-  - bcftools=1.10.2
+  - bcftools=1.11
   - tabix=0.2.6
   - samtools=1.10
   - gatk=3.8

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -127,7 +127,7 @@ def test_get_bioinfo_tools_list():
 
     # THEN assert it is a dictionary and versions are correct
     assert isinstance(bioinfo_tools_dict, dict)
-    assert set(bioinfo_tools_dict["samtools"]) == set(["1.10", "1.9"])
+    assert set(bioinfo_tools_dict["samtools"]) == set(["1.11", "1.9"])
 
 
 def test_get_delivery_id():


### PR DESCRIPTION
### This PR:

Changed:
- bumped bcftools version from 1.10.2 to 1.11

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
