### PR TITLE
Change hk deliverable tag for coverage qc report

### DIFF
--- a/BALSAMIC/commands/report/deliver.py
+++ b/BALSAMIC/commands/report/deliver.py
@@ -252,7 +252,7 @@ def deliver(context, sample_config, analysis_type, rules_to_deliver,
             "balsamic_delivery",
             "format":
             get_file_extension(balsamic_qc_report),
-            "tag": ["delivery_report"],
+            "tag": ["coverage-qc-report"],
             "id":
             case_name,
         })

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+[x.x.x]
+-------
+
+Changed
+^^^^^
+
+* Changed hk delivery tag for coverage-qc-report
+
+
 [6.1.1]
 -------
 
@@ -30,7 +39,7 @@ Changed
 Added
 ^^^^^
 
-* ``config case`` subcommand now has ``--tumor-sample-name`` and ``--normal-sample-name`` 
+* ``config case`` subcommand now has ``--tumor-sample-name`` and ``--normal-sample-name``
 
 Fixed
 ^^^^^
@@ -97,7 +106,7 @@ Changed
 
 Removed
 ^^^^^^^
-* In preparation for GATK4, IndelRealigner is removed #404 
+* In preparation for GATK4, IndelRealigner is removed #404
 
 
 [5.0.1]
@@ -164,7 +173,7 @@ Changed
 
 * Fastq files are no longer being copied as part of creation of the case config file.
   A symlink is now created at the destination path instead
-* Config structure is no longer contained in a collestion of JSON files. 
+* Config structure is no longer contained in a collestion of JSON files.
   The config models are now built using Pydantic and are contained in BALSAMIC/utils/models.py
 
 Removed
@@ -223,7 +232,7 @@ Added
 * Filter models added for tumor-only mode
 * Enabling adapter trim enables pe adapter trim option for fastp
 * Annotate germline variant calls
-* Baitset name to picard hsmetrics 
+* Baitset name to picard hsmetrics
 
 Deprecated
 ^^^^^^^^^^
@@ -329,7 +338,7 @@ Removed
 * Removed coverage annotation from mutect2
 * Removed source deactivate from rules to suppress conda warning
 * Removed ``plugins delivery`` subcommand
-* Removed annotation for germline caller results 
+* Removed annotation for germline caller results
 
 [4.1.0]
 -------
@@ -433,7 +442,7 @@ Changed
 
 
 * SLURM resource allocation for various variancalling rules optimized
-* mergetype rule updated and only accepts one single tumor instead of multiple 
+* mergetype rule updated and only accepts one single tumor instead of multiple
 
 [3.2.3] - 2019-10-24
 --------------------
@@ -543,7 +552,7 @@ Fixed
 ^^^^^
 
 
-* Fixed a bug with boolean values in analysis.json 
+* Fixed a bug with boolean values in analysis.json
 
 Changed
 ^^^^^^^
@@ -600,7 +609,7 @@ Fixed
 ^^^^^
 
 
-* Multiple fixes to snakemake rules 
+* Multiple fixes to snakemake rules
 
 Changed
 ^^^^^^^


### PR DESCRIPTION
### This PR:

Changed: hk delivery tag for coverage-qc-report

See e.g. https://github.com/Clinical-Genomics/hermes/pull/13 and https://github.com/Clinical-Genomics/cg/issues/987

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
