### PR TITLE
Feat/refactor fastp

### DIFF
--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -102,8 +102,8 @@ export TMPDIR={params.tmpdir};
 
 fastp \
 --thread {threads} \
---in1 {params.read1} \
---in2 {params.read2} \
+--in1 {input.read1} \
+--in2 {input.read2} \
 --out1 {output.read1} \
 --out2 {output.read2} \
 --json {output.json} \

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -25,25 +25,20 @@ if 'quality_trim' in config['QC'].keys():
                                 "--umi_len", config['QC']['umi_trim_length'],
                                 "--umi_prefix","UMI"])
 
-# Double pass to hard trim adapter and UMIs
-rule fastp:
+rule fastp_umi:
     input:
         read1=config["analysis"]["fastq_path"] + "{sample}" + "_1.fastq.gz",
         read2=config["analysis"]["fastq_path"] + "{sample}" + "_2.fastq.gz",
     output:
-        read1 = fastq_dir + "{sample}_1.fp.fastq.gz",
-        read2 = fastq_dir + "{sample}_2.fp.fastq.gz",
-        json = qc_dir + "fastp/{sample}_fastp.json",
-        html = qc_dir + "fastp/{sample}_fastp.html",
+        read1 = fastq_dir + "{sample}_1.umi_optimized.fastq.gz",
+        read2 = fastq_dir + "{sample}_2.umi_optimized.fastq.gz",
+        json = qc_dir + "fastp/{sample}_fastp_umi.json",
+        html = qc_dir + "fastp/{sample}_fastp_umi.html",
     benchmark:
-             benchmark_dir + "fastp_" + "{sample}_fastp.tsv"
-    singularity: Path(singularity_image, config["bioinfo_tools"].get("fastp") + ".sif").as_posix() 
+        benchmark_dir + "fastp_umi" + "{sample}_fastp.tsv"
+    singularity: 
+        Path(singularity_image, config["bioinfo_tools"].get("fastp") + ".sif").as_posix()
     params:
-        read1_interm = fastq_dir + "{sample}_1.interm.fastq.gz",
-        read2_interm = fastq_dir + "{sample}_2.interm.fastq.gz",
-        json_out_interm = fastq_dir + "{sample}_interm_fastp.json",
-        html_out_interm = fastq_dir + "{sample}_interm_fastp.html",
-        housekeeper_id = {"id": "{sample}", "tags": "quality-trimmed-fastq"},
         tmpdir = tmp_dir,
         fastq_dir = fastq_dir,
         qc = " ".join(fastp_param_qc),
@@ -64,18 +59,51 @@ fastp \
 --thread {threads} \
 --in1 {input.read1} \
 --in2 {input.read2} \
---out1 {params.read1_interm} \
---out2 {params.read2_interm} \
---json {params.json_out_interm} \
---html {params.html_out_interm} \
+--out1 {output.read1} \
+--out2 {output.read2} \
+--json {output.json} \
+--html {output.html} \
 --overrepresentation_analysis \
 {params.qc} \
 {params.adapter};
+        """
+
+# Double pass to hard trim adapter and UMIs
+rule fastp:
+    input:
+        read1 = fastq_dir + "{sample}_1.umi_optimized.fastq.gz",
+        read2 = fastq_dir + "{sample}_2.umi_optimized.fastq.gz"
+    output:
+        read1 = fastq_dir + "{sample}_1.fp.fastq.gz",
+        read2 = fastq_dir + "{sample}_2.fp.fastq.gz",
+        json = qc_dir + "fastp/{sample}_fastp.json",
+        html = qc_dir + "fastp/{sample}_fastp.html"
+    benchmark:
+        benchmark_dir + "fastp_" + "{sample}_fastp.tsv"
+    singularity: 
+        Path(singularity_image, config["bioinfo_tools"].get("fastp") + ".sif").as_posix() 
+    params:
+        housekeeper_id = {"id": "{sample}", "tags": "quality-trimmed-fastq"},
+        tmpdir = tmp_dir,
+        fastq_dir = fastq_dir,
+        qc = " ".join(fastp_param_qc),
+        umi = " ".join(fastp_param_umi),
+        adapter = " ".join(fastp_param_adapter),
+        minimum_length = config["QC"]["min_seq_length"],
+        sample_name = "{sample}",
+        conda = config["bioinfo_tools"].get("fastp")
+    threads: get_threads(cluster_config, 'fastp')
+    message:
+        "Quality control and trimming of umi optimized fastq file for {params.sample_name}"
+    shell:
+        """
+source activate {params.conda};
+export TMPDIR={params.tmpdir};
 
 fastp \
 --thread {threads} \
---in1 {params.read1_interm} \
---in2 {params.read2_interm} \
+--in1 {params.read1} \
+--in2 {params.read2} \
 --out1 {output.read1} \
 --out2 {output.read2} \
 --json {output.json} \
@@ -86,9 +114,4 @@ fastp \
 --disable_trim_poly_g \
 --length_required {params.minimum_length} \
 {params.umi};
-
-rm {params.read1_interm};
-rm {params.read2_interm};
-rm {params.json_out_interm};
-rm {params.html_out_interm};
         """

--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -40,11 +40,8 @@ rule fastp_umi:
         Path(singularity_image, config["bioinfo_tools"].get("fastp") + ".sif").as_posix()
     params:
         tmpdir = tmp_dir,
-        fastq_dir = fastq_dir,
         qc = " ".join(fastp_param_qc),
-        umi = " ".join(fastp_param_umi),
         adapter = " ".join(fastp_param_adapter),
-        minimum_length = config["QC"]["min_seq_length"],
         sample_name = "{sample}",
         conda = config["bioinfo_tools"].get("fastp")
     threads: get_threads(cluster_config, 'fastp')
@@ -85,10 +82,7 @@ rule fastp:
     params:
         housekeeper_id = {"id": "{sample}", "tags": "quality-trimmed-fastq"},
         tmpdir = tmp_dir,
-        fastq_dir = fastq_dir,
-        qc = " ".join(fastp_param_qc),
         umi = " ".join(fastp_param_umi),
-        adapter = " ".join(fastp_param_adapter),
         minimum_length = config["QC"]["min_seq_length"],
         sample_name = "{sample}",
         conda = config["bioinfo_tools"].get("fastp")

--- a/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_umiextract.rule
@@ -4,8 +4,8 @@
 # Extract umi tags using the defined read structure. 
 rule sentieon_umiextract:
     input:
-        read1 = Path(fastq_dir + "{sample}_1.fastq.gz").as_posix(),
-        read2 = Path(fastq_dir + "{sample}_2.fastq.gz").as_posix()
+        read1 = Path(fastq_dir + "{sample}_1.umi_optimized.fastq.gz").as_posix(),
+        read2 = Path(fastq_dir + "{sample}_2.umi_optimized.fastq.gz").as_posix()
     output:
         ds_umi = temp(umi_dir + "{sample}.umiextract.fastq.gz")
     benchmark:

--- a/BALSAMIC/workflows/UMIworkflow.smk
+++ b/BALSAMIC/workflows/UMIworkflow.smk
@@ -68,9 +68,6 @@ paramsumi = UMIworkflowConfig.parse_obj(umiworkflow_params)
 SAMPLES = config["samples"]
 CASE_NAME = config["analysis"]["case_id"]
 
-FILTERED_STEPS = ["consensuscalled","consensusfiltered"]
-EXTN_NAME = expand("{step}.{var_caller}_umi", var_caller = ["TNscope"], step=FILTERED_STEPS)
-
 # Define outputs
 analysis_output = [expand(vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.pass.vcf.gz", var_type= "SNV", case_name=CASE_NAME, var_caller=["TNscope_umi"]),
 expand(umi_qc_dir + "{sample}.umi.{metric}", sample=SAMPLES, metric = ["metrics", "mean_family_depth"])]


### PR DESCRIPTION
### This PR:
For UMI workflow, 5' adapter sequences need to trimmed prior to umi extract. In this PR, `fastp` rule is splitted into two different rules, where resultant outputs can be either used for balsamic or UMIworkflow.


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
