### PR TITLE
Refactor/small umi fixes

### DIFF
--- a/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
+++ b/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
@@ -20,7 +20,7 @@ rule bcftools_query_generatebackgroundaf_umitable:
     message: 
         "Creating Allelic frequency table from VCF file for sample {params.sample_id}"
     shell:
-      """
+        """
 source activate {params.conda};
 bcftools query \
 --regions-file {params.validated_set} \
@@ -30,4 +30,3 @@ awk -v file={params.sample_id} \
 \'{{print $1\":\"$2\"_\"$3\"->\"$4\"\\t\"$5\"\\t\"$6\"\\t\"file}}\' \
 > {output.AF};
         """
-

--- a/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
+++ b/BALSAMIC/snakemake_rules/umi/generate_AF_tables.rule
@@ -20,13 +20,14 @@ rule bcftools_query_generatebackgroundaf_umitable:
     message: 
         "Creating Allelic frequency table from VCF file for sample {params.sample_id}"
     shell:
-        """
+      """
 source activate {params.conda};
 bcftools query \
 --regions-file {params.validated_set} \
--f \"%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%AF\\t%AD{{0}}\\t%AD{{1}}]\n\" \
+-f \"%CHROM\\t%POS\\t%REF\\t%ALT\\t%FILTER\\t[%AF\\t]\n\" \
 {input.vcf} | \
 awk -v file={params.sample_id} \
-\'{{print $1\":\"$2\"_\"$3\"->\"$4\"\\t\"$8/($7+$8)\"\\t\"file}}\' \
+\'{{print $1\":\"$2\"_\"$3\"->\"$4\"\\t\"$5\"\\t\"$6\"\\t\"file}}\' \
 > {output.AF};
         """
+

--- a/BALSAMIC/snakemake_rules/umi/qc_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/qc_umi.rule
@@ -25,6 +25,7 @@ rule picard_umiaware:
 source activate {params.conda};
 
 picard UmiAwareMarkDuplicatesWithMateCigar \
+--DUPLEX_UMI=TRUE \
 I={input.bam} \
 O={output.bam} \
 M={output.duplicates} \
@@ -65,7 +66,9 @@ picard CollectHsMetrics \
 BI={input.bam}.picard.bedintervals \
 TI={input.bam}.picard.bedintervals \
 I={input.bam} \
-O={output.mrkdup};
+R={input.fa} \
+O={output.mrkdup} \
+COVERAGE_CAP=50000;
         """
 
 ## SUM(Reads in each family)/ the number of families after correction, collapsing on supporting reads.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,17 @@
+[7.1.8]
+-------
+
+Fixed:
+^^^^^^
+
+* Target coverage (Picard HsMetrics) for UMI files is now correctly calculated.
+
+Changed:
+^^^^^^
+
+*  TNscope calculated AF values are fetched and written to AFtable.txt.
+
+
 [7.1.7]
 -------
 


### PR DESCRIPTION
### This PR:

- Target coverage for UMI files is wrongly calculated in Picard HSmetrics. Set Coverage_cap to 500.
- Previously, AFtables are calculated using formulae (AF=allelic depth of Alt. allele / (Allelic depths for the Ref + Alt. alleles)). Now, this is modified and directly TNscope calculated AF values are fetched and written to AFtable.txt.

