### PR TITLE
setting sentieon wgs to pcr-free

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_germline.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_germline.rule
@@ -11,6 +11,7 @@ rule sentieon_DNAscope:
         vcf = vcf_dir + "SNV.germline.{sample_type}.dnascope.vcf.gz",
     params:
         tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
+        pcr_model = "NONE",
         sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
         sentieon_ml_dnascope = config["SENTIEON_DNASCOPE"]
@@ -25,6 +26,13 @@ export SENTIEON_TMPDIR={params.tmpdir};
 export SENTIEON_LICENSE={params.sentieon_lic};
 export SENTIEON_DNASCOPE={params.sentieon_ml_dnascope};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} -i {input.bam} -q {input.recal_table} --algo DNAscope -d {input.dbsnp} {output.vcf}
+{params.sentieon_exec} driver \
+-t {threads} \
+-r {input.ref} \
+-i {input.bam} \
+-q {input.recal_table} \
+--algo DNAscope \
+--pcr_indel_mode {params.pcr_model} \
+-d {input.dbsnp} {output.vcf};
 rm -rf {params.tmpdir};
       """

--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_t_varcall.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_t_varcall.rule
@@ -60,6 +60,7 @@ rule sentieon_TNhaplotyper_tumor_only:
         tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
         tumor = "TUMOR", 
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]),
+        pcr_model = "NONE",
         sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper_tumor_only')
@@ -72,7 +73,16 @@ export TMPDIR={params.tmpdir};
 export SENTIEON_TMPDIR={params.tmpdir};
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} -q {input.recal_data_table} --algo TNhaplotyper --tumor_sample {params.tumor} {params.pon} --cosmic {input.cosmic} --dbsnp {input.dbsnp} {output.vcf} 
+{params.sentieon_exec} driver \
+-r {input.ref} \
+-t {threads} \
+-i {input.bam} \
+-q {input.recal_data_table} \
+--algo TNhaplotyper \
+--tumor_sample {params.tumor} {params.pon} \
+--pcr_indel_mode {params.pcr_model} \
+--cosmic {input.cosmic} \
+--dbsnp {input.dbsnp} {output.vcf};
 
 echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap}; 
 rm -rf {params.tmpdir};
@@ -94,6 +104,7 @@ rule sentieon_TNscope_tumor_only:
         tumor = "TUMOR", 
         tumor_options = VARCALL_PARAMS["tnscope"]["tumor"], 
         pon = " " if get_pon(config) is None else " ".join(["--pon", get_pon(config)]),
+        pcr_model = "NONE",
         sentieon_ml_tnscope = config["SENTIEON_TNSCOPE"],
         sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
@@ -107,10 +118,15 @@ export TMPDIR={params.tmpdir};
 export SENTIEON_TMPDIR={params.tmpdir};
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver -t {threads} -r {input.ref} \
--i {input.bam} -q {input.recal} --algo TNscope \
+{params.sentieon_exec} driver \
+-t {threads} \
+-r {input.ref} \
+-i {input.bam} \
+-q {input.recal} \
+--algo TNscope \
 --tumor_sample {params.tumor} {params.pon} \
 --dbsnp {input.dbsnp} \
+--pcr_indel_mode {params.pcr_model} \
 {params.tumor_options} {output.vcf};
 
 echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap_snv};

--- a/BALSAMIC/snakemake_rules/variant_calling/sentieon_tn_varcall.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/sentieon_tn_varcall.rule
@@ -82,7 +82,8 @@ rule sentieon_TNhaplotyper:
     params:
         tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
         tumor = "TUMOR", 
-        normal = "NORMAL", 
+        normal = "NORMAL",
+        pcr_model = "NONE", 
         sentieon_exec = config["SENTIEON_EXEC"],
         sentieon_lic = config["SENTIEON_LICENSE"],
     threads: get_threads(cluster_config, 'sentieon_TNhaplotyper')
@@ -97,7 +98,15 @@ export TMPDIR={params.tmpdir};
 export SENTIEON_TMPDIR={params.tmpdir};
 export SENTIEON_LICENSE={params.sentieon_lic};
 
-{params.sentieon_exec} driver -r {input.ref} -t {threads} -i {input.bam} --algo TNhaplotyper --tumor_sample {params.tumor} --normal_sample {params.normal} --dbsnp {input.dbsnp} {output.vcf}
+{params.sentieon_exec} driver \
+-r {input.ref} \
+-t {threads} \
+-i {input.bam} \
+--algo TNhaplotyper \
+--tumor_sample {params.tumor} \
+--normal_sample {params.normal} \
+--pcr_indel_mode {params.pcr_model} \
+--dbsnp {input.dbsnp} {output.vcf};
 
 echo -e \"{params.tumor}\\tTUMOR\\n{params.normal}\\tNORMAL\" > {output.namemap};
 rm -rf {params.tmpdir};
@@ -120,6 +129,7 @@ rule sentieon_TNscope:
         tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
         tumor = "TUMOR",
         normal = "NORMAL",
+        pcr_model = "NONE",
         tumor_options = VARCALL_PARAMS["tnscope"]["tumor"], 
         normal_options = VARCALL_PARAMS["tnscope"]["normal"], 
         sentieon_ml_tnscope = config["SENTIEON_TNSCOPE"],
@@ -139,14 +149,26 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 
 intermediate_vcf={params.tmpdir}/tn_sentieon_varcall_file
 
-{params.sentieon_exec} driver -t {threads} \
--r {input.ref} -i {input.bamT} -q {input.recalT} -i {input.bamN} \
--q {input.recalN} --algo TNscope --tumor_sample {params.tumor} \
---normal_sample {params.normal} --dbsnp {input.dbsnp} \
-{params.tumor_options} {params.normal_options} $intermediate_vcf 
+{params.sentieon_exec} driver \
+-t {threads} \
+-r {input.ref} \
+-i {input.bamT} \
+-q {input.recalT} \
+-i {input.bamN} \
+-q {input.recalN} \
+--algo TNscope \
+--tumor_sample {params.tumor} \
+--normal_sample {params.normal} \
+--dbsnp {input.dbsnp} \
+--pcr_indel_mode {params.pcr_model} \
+{params.tumor_options} \
+{params.normal_options} $intermediate_vcf;
 
-{params.sentieon_exec} driver -r {input.ref} --algo TNModelApply \
--m {params.sentieon_ml_tnscope} -v $intermediate_vcf {output.vcf_all}
+{params.sentieon_exec} driver \
+-r {input.ref} \
+--algo TNModelApply \
+-m {params.sentieon_ml_tnscope} \
+-v $intermediate_vcf {output.vcf_all};
 
 echo -e \"{params.tumor}\\tTUMOR\\n{params.normal}\\tNORMAL\" > {output.namemap_snv};
 cp {output.namemap_snv} {output.namemap_sv}


### PR DESCRIPTION
### This PR:

For Sentieon wgs rules (TNscope, TNhaplotyper and DNAscope), setting the pcr-free-indel model to NONE.



