### PR TITLE
add tumor lod option for passing final variants

### DIFF
--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -21,6 +21,7 @@ rule sentieon_tnscope_umi:
         algo = paramsumi.tnscope.algo,
         disable_detect = paramsumi.tnscope.disable_detect,
         tumor_lod = paramsumi.tnscope.min_tumorLOD,
+        init_tumor_lod = paramsumi.tnscope.init_tumorLOD,
         error_rate = paramsumi.tnscope.error_rate,
         prune_factor = paramsumi.tnscope.prunefactor,
         tumor = "TUMOR"
@@ -39,7 +40,8 @@ rule sentieon_tnscope_umi:
 --dbsnp {input.dbsnp} \
 --min_tumor_allele_frac {params.tumor_af} \
 --filter_t_alt_frac {params.tumor_af} \
---min_init_tumor_lod {params.tumor_lod} \
+--min_init_tumor_lod {params.init_tumor_lod} \
+--min_tumor_lod {params.tumor_lod} \
 --disable_detector {params.disable_detect} \
 --max_error_per_read {params.error_rate} \
 --pcr_indel_model NONE \

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope_tn.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope_tn.rule
@@ -21,6 +21,7 @@ rule sentieon_tnscope_umi_tn:
         algo = paramsumi.tnscope.algo,
         disable_detect = paramsumi.tnscope.disable_detect,
         tumor_lod = paramsumi.tnscope.min_tumorLOD,
+        init_tumor_lod = paramsumi.tnscope.init_tumorLOD,
         error_rate = paramsumi.tnscope.error_rate,
         prune_factor = paramsumi.tnscope.prunefactor,
         tumor = "TUMOR",
@@ -43,7 +44,8 @@ rule sentieon_tnscope_umi_tn:
 --dbsnp {input.dbsnp} \
 --min_tumor_allele_frac {params.tumor_af} \
 --filter_t_alt_frac {params.tumor_af} \
---min_init_tumor_lod {params.tumor_lod} \
+--min_init_tumor_lod {params.init_tumor_lod} \
+--min_tumor_lod {params.tumor_lod} \
 --disable_detector {params.disable_detect} \
 --max_error_per_read {params.error_rate} \
 --pcr_indel_model NONE \

--- a/BALSAMIC/utils/constants.py
+++ b/BALSAMIC/utils/constants.py
@@ -534,7 +534,8 @@ umiworkflow_params = {
     },
     "tnscope": {
         "algo": "TNscope",
-        "min_tumorLOD": 0.5,
+        "min_tumorLOD": 4,
+        "init_tumorLOD": 0.5,
         "error_rate": 5,
         "prunefactor": 3,
         "disable_detect": "sv"

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -61,8 +61,8 @@ class VarCallerFilter(BaseModel):
     DP: Optional[VCFAttributes]
     pop_freq: VCFAttributes
     strand_reads: Optional[VCFAttributes]
-    qss : Optional[VCFAttributes]
-    sor : Optional[VCFAttributes]
+    qss: Optional[VCFAttributes]
+    sor: Optional[VCFAttributes]
     varcaller_name: str
     filter_type: str
     analysis_type: str

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -573,7 +573,7 @@ class UMIworkflowConfig(BaseModel):
 	umiextract: params defined in the rule sentieon_umiextract
 	consensuscall: params defined in the rule sentieon_consensuscall
 	tnscope: params defined in the rule sentieon_tnscope_umi
-    vardict: params defined in the rule vardict_umi
+	vardict: params defined in the rule vardict_umi
 	vep: params defined in the rule vep_umi
     """
     common: UMIParamsCommon

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -531,13 +531,15 @@ class UMIParamsTNscope(BaseModel):
         algo: str; choice of sentieon varcall algorithm. eg. 'TNscope'
         disable_detect: str; disable variant detector. eg 'sv' or 'snv_indel'
         filter_tumor_af: float (required); minimum allelic frequency to detect
-        min_tumorLOD: float (required); Minimum tumorLOD value
-        error_rate: int (required); allow error-rate to consider in calling
+        min_tumorLOD: int (required); minimum tumor log odds in the final call of variants
+        init_tumorLOD: float (required); minimum tumor log odds in the initial pass calling variants
+	error_rate: int (required); allow error-rate to consider in calling
         prunefactor: int (required); pruning factor in the kmer graph
     """
 
     algo: str
-    min_tumorLOD: float
+    init_tumorLOD: float
+    min_tumorLOD: int
     error_rate: int
     prunefactor: int
     disable_detect: str

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -23,9 +23,9 @@ class VCFAttributes(BaseModel):
     A value of 5 from INFO field and filter_name will be balsamic_low_tumor_ad
 
     Attributes:
-      tag_value: float
-      filter_name: str
-      field: str
+        tag_value: float
+        filter_name: str
+        field: str
     """
 
     tag_value: float
@@ -45,10 +45,10 @@ class VarCallerFilter(BaseModel):
         MQ: VCFAttributes (optional); minimum mapping quality
         DP: VCFAttributes (optional); minimum read depth
         pop_freq: VCFAttributes (optional); maximum gnomad_af
-	strand_reads: VCFAttributes (optional); minimum strand specific read counts 
+	    strand_reads: VCFAttributes (optional); minimum strand specific read counts
         qss: VCFAttributes (optional); minimum sum of base quality scores
-	sor: VCFAttributes (optional); minimum symmetrical log-odds ratio  
-	varcaller_name: str (required); variant caller name
+	    sor: VCFAttributes (optional); minimum symmetrical log-odds ratio
+	    varcaller_name: str (required); variant caller name
         filter_type: str (required); filter name for variant caller
         analysis_type: str (required); analysis type e.g. tumor_normal or tumor_only
         description: str (required); comment section for description
@@ -515,7 +515,7 @@ class UMIParamsConsensuscall(BaseModel):
 
     Attributes:
         align_format: str (required); output alignment format. eg. 'BAM'
-	filter_minreads: str (required); settings to filter consensus tags based on group size
+	    filter_minreads: str (required); settings to filter consensus tags based on group size
         tag: str; Logic UMI tag
     """
 
@@ -533,7 +533,7 @@ class UMIParamsTNscope(BaseModel):
         filter_tumor_af: float (required); minimum allelic frequency to detect
         min_tumorLOD: int (required); minimum tumor log odds in the final call of variants
         init_tumorLOD: float (required); minimum tumor log odds in the initial pass calling variants
-	error_rate: int (required); allow error-rate to consider in calling
+	    error_rate: int (required); allow error-rate to consider in calling
         prunefactor: int (required); pruning factor in the kmer graph
     """
 
@@ -573,7 +573,7 @@ class UMIworkflowConfig(BaseModel):
 	umiextract: params defined in the rule sentieon_umiextract
 	consensuscall: params defined in the rule sentieon_consensuscall
 	tnscope: params defined in the rule sentieon_tnscope_umi
-    	vardict: params defined in the rule vardict_umi
+    vardict: params defined in the rule vardict_umi
 	vep: params defined in the rule vep_umi
     """
     common: UMIParamsCommon

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Added:
 
 * Changelog reminder workflow to Github
 * Snakemake workflow for created PON reference
+* Added tumor lod option for passing tnscope-umi final variants
 
 [7.1.10]
 -------

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -336,7 +336,8 @@ def test_umiparams_tnscope():
     #GIVEN tnscope params
     test_tnscope_params = {
         "algo": "algoname",
-        "min_tumorLOD": 6,
+        "init_tumorLOD": 0.5,
+	"min_tumorLOD": 6,
         "error_rate": 5,
         "prunefactor": 3,
         "disable_detect": "abc"
@@ -347,6 +348,7 @@ def test_umiparams_tnscope():
 
     #THEN assert values
     assert test_tnscope_params_built.algo == "algoname"
+    assert test_tnscope_params_built.init_tumorLOD == 0.5
     assert test_tnscope_params_built.min_tumorLOD == 6
     assert test_tnscope_params_built.error_rate == 5
     assert test_tnscope_params_built.prunefactor == 3

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -337,7 +337,7 @@ def test_umiparams_tnscope():
     test_tnscope_params = {
         "algo": "algoname",
         "init_tumorLOD": 0.5,
-	    "min_tumorLOD": 6,
+        "min_tumorLOD": 6,
         "error_rate": 5,
         "prunefactor": 3,
         "disable_detect": "abc"

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -337,7 +337,7 @@ def test_umiparams_tnscope():
     test_tnscope_params = {
         "algo": "algoname",
         "init_tumorLOD": 0.5,
-	"min_tumorLOD": 6,
+	    "min_tumorLOD": 6,
         "error_rate": 5,
         "prunefactor": 3,
         "disable_detect": "abc"


### PR DESCRIPTION
### This PR:

Variant calling with TNScope in UMIworkflow, tumor lod option uses the default (value 6.2) for passing the final called variants. Now added this parameter to the command-line, and the default value can be controlled via constants.


Tumor LOD default values for tumor and normal in SENTIEON are set according to the mutect. Read more [here](https://software.broadinstitute.org/cancer/cga/mutect)
