### PR TITLE
Fix/umi post process

### DIFF
--- a/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_consensuscall.rule
@@ -66,6 +66,7 @@ export MALLOC_CONF=lg_dirty_mult:-1
 {params.sentieon_exec} util sort \
 -r {input.ref_fa} \
 --sam2bam \
+--umi_post_process \
 -o {output.align_consensus} \
 -i - ;
         """

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+[7.X.X]
+-------
+
+Changed:
+^^^^^^^^
+* Upgrade to latest sentieon version 202010.02
+
+
+Fixed:
+^^^^^^
+* post-processing of the umi consensus in handling BI tags
+
+
 [7.2.2]
 -------
 


### PR DESCRIPTION
### This PR:

If updating to sentieon's latest version (v202010.02)., the existing umiworkflow needs a small update to the rule `sentieon_bwa_umiconsensus` with `--umi_post_process` option which will instruct the consensus tool to perform the necessary post-processing of the consensus in proper handling of INDEL quality scores (BI tags) .


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
