### PR TITLE
Include all filtered variants in vcf-filtered-clinical not just PASSed

### DIFF
--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
@@ -24,7 +24,7 @@ rule ngs_filter_vardict:
   shell:
     """
 source activate {params.conda};
-bcftools view -f PASS {input.vcf} \
+bcftools view {input.vcf} \
 | bcftools filter --include 'SMPL_MIN(FMT/MQ) >= {params.MQ[0]}' --soft-filter '{params.MQ[1]}' --mode + \
 | bcftools filter --include 'INFO/DP >= {params.DP[0]}' --soft-filter '{params.DP[1]}' --mode '+' \
 | bcftools filter --include 'INFO/VD >= {params.AD[0]}' --soft-filter '{params.AD[1]}' --mode '+' \

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
@@ -24,7 +24,7 @@ rule ngs_filter_vardict:
   shell:
     """
 source activate {params.conda};
-bcftools view -f PASS {input.vcf} \
+bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/MQ >= {params.MQ[0]}' --soft-filter '{params.MQ[1]}' --mode '+' \
 | bcftools filter --include 'INFO/DP >= {params.DP[0]}' --soft-filter '{params.DP[1]}' --mode '+' \
 | bcftools filter --include 'INFO/VD >= {params.AD[0]}' --soft-filter '{params.AD[1]}' --mode '+' \

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
@@ -23,7 +23,7 @@ rule ngs_filter_tnscope:
   shell:
     """
 source activate {params.conda};
-bcftools view -f PASS {input.vcf} \
+bcftools view {input.vcf} \
 | bcftools filter --threads {threads} --include 'SUM(FORMAT/AD[0:0]+FORMAT/AD[0:1]) >= {params.DP[0]} || SUM(FORMAT/AD[1:0]+FORMAT/AD[1:1]) >= {params.DP[0]}' --soft-filter '{params.DP[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/AD[0:1] >= {params.AD[0]}' --soft-filter '{params.AD[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/AF[0] >= {params.AF_min[0]}' --soft-filter '{params.AF_min[1]}' --mode '+' \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changed:
 Fixed:
 ^^^^^^
 * post-processing of the umi consensus in handling BI tags
+* vcf-filtered-clinical tag files will have all variants including PASS
 
 
 [7.2.2]


### PR DESCRIPTION
### This PR:

Fixed:

- vcf-filtered-clinical tag only had PASSed variants with further filters. Fixed such it also preserves VarDict filters and not just `PASS`

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
