### PR TITLE
fix: uses bcftools stats to generate ti/tv

### DIFF
--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -10,6 +10,7 @@ rule vep_somatic:
   output:
     vcf_all = vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.all.vcf.gz",
     vcf_summary = vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.all.vcf.gz_summary.html",
+    bcftools_stats = vep_dir + "{var_type}.somatic.{case_name}.{var_caller}.all.stats"
   benchmark:
     Path(benchmark_dir, "vep_somatic_{var_type}.somatic.{case_name}.{var_caller}.tsv").as_posix()
   singularity:
@@ -50,6 +51,9 @@ vep \
 --custom {input.cosmic},COSMIC,vcf,exact,0,CDS,GENE,STRAND,CNT,AA \
 
 tabix -p vcf -f {output.vcf_all};
+
+bcftools stats {output.vcf_all} > {output.bcftools_stats};
+
 rm $tmpvcf;
     """
 
@@ -97,6 +101,7 @@ rule vep_germline:
   output:
     vcf_all = vep_dir + "{var_type}.germline.{sample}.{var_caller}.vcf.gz",
     vcf_summary = vep_dir + "{var_type}.germline.{sample}.{var_caller}.vcf.gz_summary.html",
+    bcftools_stats = vep_dir + "{var_type}.germline.{case_name}.{var_caller}.all.stats"
   benchmark:
     Path(benchmark_dir, "vep_germline_{var_type}.germline.{sample}.{var_caller}.tsv").as_posix()
   singularity:
@@ -127,5 +132,8 @@ vep \
 --fork {threads} \
 {params.vep_defaults} \
 --custom {input.cosmic},COSMIC,vcf,exact,0,CDS,GENE,STRAND,CNT,AA \
+
 tabix -p vcf -f {output.vcf_all};
+
+bcftools stats {output.vcf_all} > {output.bcftools_stats};
     """

--- a/BALSAMIC/snakemake_rules/annotation/vep.rule
+++ b/BALSAMIC/snakemake_rules/annotation/vep.rule
@@ -101,7 +101,7 @@ rule vep_germline:
   output:
     vcf_all = vep_dir + "{var_type}.germline.{sample}.{var_caller}.vcf.gz",
     vcf_summary = vep_dir + "{var_type}.germline.{sample}.{var_caller}.vcf.gz_summary.html",
-    bcftools_stats = vep_dir + "{var_type}.germline.{case_name}.{var_caller}.all.stats"
+    bcftools_stats = vep_dir + "{var_type}.germline.{sample}.{var_caller}.all.stats"
   benchmark:
     Path(benchmark_dir, "vep_germline_{var_type}.germline.{sample}.{var_caller}.tsv").as_posix()
   singularity:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@
 
 Added:
 * Workflow to check PR tiltes to make easier to tell PR intents #724
-
+* ``bcftools stats``  to calculate Ti/Tv for all post annotate germline and somatic calls #93
 
 [8.0.1]
 -------


### PR DESCRIPTION
### This PR:

Fixes:
- Use bcftools stats to generate Ti/TV which will be picked up by MultiQC #93 

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
