### PR TITLE
refactor: rename pon reference filename

### DIFF
--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -38,10 +38,21 @@ picarddup = get_picard_mrkdup(config)
 samples = get_pon_samples(fastq_dir)
 
 
+panel_ref_dir = os.path.split(target_bed)[0]
+panel_name = os.path.split(target_bed)[1].replace('.bed','')
+
+pon_dir = panel_ref_dir + "/" + "PON_references" + "/"
+
+if not os.path.exists(pon_directory):
+    os.makedirs(pon_directory)
+
 ALL_COVS = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
 ALL_REFS = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
-ALL_PON = expand(cnv_dir + config["analysis"]["case_id"] + "_PON_reference.cnn")
-PON_DONE = expand(cnv_dir + "PON." + "reference" + ".done")
+ALL_PON = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
+PON_DONE = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
+
+#ALL_PON = expand(cnv_dir + config["analysis"]["case_id"] + "_PON_reference.cnn")
+#PON_DONE = expand(cnv_dir + "PON." + "reference" + ".done")
 
 config["rules"] = ["snakemake_rules/quality_control/fastp.rule", 
                    "snakemake_rules/align/bwa_mem.rule"]
@@ -95,8 +106,8 @@ rule create_reference:
         cnn = expand(cnv_dir + "{sample}.{prefix}coverage.cnn", sample=samples, prefix=["target","antitarget"]),
         ref = reffasta
     output:
-        ref_cnn = cnv_dir + config["analysis"]["case_id"] + "_PON_reference.cnn",
-        txt = cnv_dir + "PON." + "reference" + ".done"
+        ref_cnn = ALL_PON,
+        txt = PON_done
     singularity:
         Path(singularity_image, "varcall_cnvkit.sif").as_posix()
     benchmark:

--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -37,10 +37,8 @@ Path.mkdir(Path(tmp_dir), exist_ok=True)
 picarddup = get_picard_mrkdup(config)
 samples = get_pon_samples(fastq_dir)
 
-
 panel_ref_dir = os.path.split(target_bed)[0]
 panel_name = os.path.split(target_bed)[1].replace('.bed','')
-
 pon_dir = panel_ref_dir + "/" + "PON_references" + "/"
 
 if not os.path.exists(pon_dir):
@@ -50,9 +48,6 @@ ALL_COVS = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['
 ALL_REFS = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
 ALL_PON = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
 PON_DONE = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
-
-#ALL_PON = expand(cnv_dir + config["analysis"]["case_id"] + "_PON_reference.cnn")
-#PON_DONE = expand(cnv_dir + "PON." + "reference" + ".done")
 
 config["rules"] = ["snakemake_rules/quality_control/fastp.rule", 
                    "snakemake_rules/align/bwa_mem.rule"]

--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -37,17 +37,12 @@ Path.mkdir(Path(tmp_dir), exist_ok=True)
 picarddup = get_picard_mrkdup(config)
 samples = get_pon_samples(fastq_dir)
 
-panel_ref_dir = os.path.split(target_bed)[0]
 panel_name = os.path.split(target_bed)[1].replace('.bed','')
-pon_dir = panel_ref_dir + "/" + "PON_references" + "/"
-
-if not os.path.exists(pon_dir):
-    os.makedirs(pon_dir)
 
 coverage_references = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
 baited_beds = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
-pon_reference = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
-pon_finish = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
+pon_reference = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
+pon_finish = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
 
 config["rules"] = ["snakemake_rules/quality_control/fastp.rule", 
                    "snakemake_rules/align/bwa_mem.rule"]

--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -44,10 +44,10 @@ pon_dir = panel_ref_dir + "/" + "PON_references" + "/"
 if not os.path.exists(pon_dir):
     os.makedirs(pon_dir)
 
-ALL_COVS = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
-ALL_REFS = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
-ALL_PON = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
-PON_DONE = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
+coverage_references = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
+baited_beds = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
+pon_reference = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
+pon_finish = expand(pon_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
 
 config["rules"] = ["snakemake_rules/quality_control/fastp.rule", 
                    "snakemake_rules/align/bwa_mem.rule"]
@@ -56,7 +56,7 @@ for r in config["rules"]:
     include: Path(RULE_DIRECTORY, r).as_posix()
 
 rule all:
-    input: ALL_REFS + ALL_COVS +  PON_DONE
+    input: pon_finish 
 
 rule create_target:
     input:
@@ -101,8 +101,8 @@ rule create_reference:
         cnn = expand(cnv_dir + "{sample}.{prefix}coverage.cnn", sample=samples, prefix=["target","antitarget"]),
         ref = reffasta
     output:
-        ref_cnn = ALL_PON,
-        txt = PON_DONE
+        ref_cnn = pon_reference,
+        txt = pon_finish
     singularity:
         Path(singularity_image, "varcall_cnvkit.sif").as_posix()
     benchmark:

--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -43,8 +43,8 @@ panel_name = os.path.split(target_bed)[1].replace('.bed','')
 
 pon_dir = panel_ref_dir + "/" + "PON_references" + "/"
 
-if not os.path.exists(pon_directory):
-    os.makedirs(pon_directory)
+if not os.path.exists(pon_dir):
+    os.makedirs(pon_dir)
 
 ALL_COVS = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
 ALL_REFS = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
@@ -107,7 +107,7 @@ rule create_reference:
         ref = reffasta
     output:
         ref_cnn = ALL_PON,
-        txt = PON_done
+        txt = PON_DONE
     singularity:
         Path(singularity_image, "varcall_cnvkit.sif").as_posix()
     benchmark:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changed:
 ^^^^^^^^
 
 * Updated docs for git FAQs #731
-* Storing PON references in production target panel location Clinical-Genomics/cgp-cancer-cnvcall#10 
+* Rename panel of normal filename Clinical-Genomics/cgp-cancer-cnvcall#10 
 
 [8.0.2]
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changed:
 ^^^^^^^^
 
 * Updated docs for git FAQs #731
+* Storing PON references in production target panel location Clinical-Genomics/cgp-cancer-cnvcall#10 
 
 [8.0.2]
 -------


### PR DESCRIPTION
### This PR:

Changed:

Rename the PON reference filename with more descriptive details as from which panel and case_id, the output PON is generated. Related to https://github.com/Clinical-Genomics/cgp-cancer-cnvcall/issues/10

To reproduce:

```
balsamic config pon --case-id securetoad10 -p /home/proj/production/cancer/reference/target_capture_bed/production/balsamic/gmcksolid_4.1_hg19_design.bed --balsamic-cache /home/proj/stage/cancer/balsamic_cache/ --analysis-dir /home/proj/long-term-stage/cancer/PON_analysis_runs_APJ/PON_test_datasets/ --fastq-path /home/proj/production/cancer/cases/securetoad/fastq/ -g hg19

balsamic run analysis -s /home/proj/long-term-stage/cancer/PON_analysis_runs_APJ/PON_test_datasets/securetoad10/securetoad10_PON.json 

```

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
