### PR TITLE
fix: libreadline.so in varcall_py36 issue 739

### DIFF
--- a/BALSAMIC/containers/varcall_py36/varcall_py36.sh
+++ b/BALSAMIC/containers/varcall_py36/varcall_py36.sh
@@ -1,5 +1,5 @@
 conda env create -n ${1} --file ${1}.yaml
 source activate ${1}
 ENV_PATH=/opt/conda/envs
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.0 ${ENV_PATH}/${1}/lib/libreadline.so.6
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.0 ${ENV_PATH}/${1}/lib/libreadline.so.6.0
+ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.1 ${ENV_PATH}/${1}/lib/libreadline.so.6
+ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.1 ${ENV_PATH}/${1}/lib/libreadline.so.6.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changed:
 ^^^^^^^^
 
 * Updated docs for git FAQs #731
-* Changed softlinks for libreadline.so in varcall_py36 container #739
+* Changed softlinks from libreadline.so.8.1 to libreadline.so.6 in varcall_py36 container #739
 
 [8.0.2]
 -------


### PR DESCRIPTION
### This PR:

Changed: softlinks from libreadline.so.8.1 to libreadline.so.6 in varcall_py36

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
