### PR TITLE
fix: removed libreadline.so symlinking, and fixed R version to 3.6.2 for varcall_py36 container

### DIFF
--- a/BALSAMIC/containers/align_qc/align_qc.sh
+++ b/BALSAMIC/containers/align_qc/align_qc.sh
@@ -1,5 +1,1 @@
 conda env create -n ${1} --file ${1}.yaml
-source activate ${1}
-ENV_PATH=/opt/conda/envs
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.7.0 ${ENV_PATH}/${1}/lib/libreadline.so.6
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.7.0 ${ENV_PATH}/${1}/lib/libreadline.so.6.0

--- a/BALSAMIC/containers/varcall_py36/varcall_py36.sh
+++ b/BALSAMIC/containers/varcall_py36/varcall_py36.sh
@@ -1,5 +1,1 @@
 conda env create -n ${1} --file ${1}.yaml
-source activate ${1}
-ENV_PATH=/opt/conda/envs
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.0 ${ENV_PATH}/${1}/lib/libreadline.so.6
-ln -s ${ENV_PATH}/${1}/lib/libreadline.so.8.0 ${ENV_PATH}/${1}/lib/libreadline.so.6.0

--- a/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
+++ b/BALSAMIC/containers/varcall_py36/varcall_py36.yaml
@@ -10,3 +10,4 @@ dependencies:
   - bioconda::vardict=2019.06.04=pl526_0
   - bioconda::vardict-java=1.7
   - conda-forge::libiconv
+  - conda-forge::r-base=3.6.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,11 @@ Changed:
 ^^^^^^^^
 
 * Updated docs for git FAQs #731
-* Changed softlinks for libreadline.so in varcall_py36 container #739
+
+Fixed:
+^^^^^^
+
+* Fixed bug with using varcall_py36 container with VarDict #739
 
 [8.0.2]
 -------


### PR DESCRIPTION
### This PR:

Fixed:
- Removed libreadline linking, and fixed R version to 3.6.2 fixes #739 

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
