### PR TITLE
fix: bcftools stats not parsed by MultiQC

### DIFF
--- a/BALSAMIC/containers/align_qc/align_qc.yaml
+++ b/BALSAMIC/containers/align_qc/align_qc.yaml
@@ -8,7 +8,7 @@ dependencies:
   - bioconda::samtools=1.12
   - bioconda::tabix=0.2.6
   - bioconda::picard=2.25.0
-  - bioconda::multiqc=1.9
+  - bioconda::multiqc=1.11
   - bioconda::fastp=0.20.1
   - conda-forge::csvkit=1.0.4
   - conda-forge::libiconv

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed:
 ^^^^^^
 
 * Fixed bug with using varcall_py36 container with VarDict #739
+* Fixed a bug with ``bcftools stats`` results failing in MultiQC #744
 
 [8.0.2]
 -------


### PR DESCRIPTION
### This PR:

Fixed:
- fixes #744 by bumping multiqc to most recent version

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
