### PR TITLE
fix: remove VEP from multiqc modules

### DIFF
--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -75,7 +75,8 @@ rule multiqc:
         dir_list = result_dir,
         qc_dir = qc_dir,
         conda = config["bioinfo_tools"].get("multiqc"),
-        case_name = config["analysis"]["case_id"]
+        case_name = config["analysis"]["case_id"],
+        exclude_module = "vep"
     message:
         "Aggregrate quality metrics results using multiqc for sample {params.case_name}"
     shell:
@@ -83,6 +84,6 @@ rule multiqc:
 source activate {params.conda};
 
 echo -e \"{params.dir_list}\" > {params.qc_dir}/dir_list;
-multiqc --force --outdir {params.qc_dir} --data-format json -l {params.qc_dir}/dir_list;
+multiqc --force --outdir {params.qc_dir} --exclude {params.exclude_module} --data-format json -l {params.qc_dir}/dir_list;
 chmod -R 777 {params.qc_dir};
         """

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed:
 ^^^^^^
 
 * Fixed bug with using varcall_py36 container with VarDict #739
+* Fixed a bug with VEP module in MultiQC by excluding #746
 
 [8.0.2]
 -------


### PR DESCRIPTION
### This PR:

Fixed:
- fixes #746 by excluding VEP from multiqc due to a bug with multiqc

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
