### PR TITLE
fix: cryptography version to address failing builds

### DIFF
--- a/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
+++ b/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
@@ -3,8 +3,8 @@ channels:
   - defaults
 
 dependencies:
-  - anaconda::python=3.6
-  - conda-forge::pip=9.0.3
+  - conda-forge::python=3.7
+  - conda-forge::pip
   - conda-forge::r-base=4.1.0
   - conda-forge::r-optparse=1.6.6
   - bioconda::bioconductor-iranges=2.26.0
@@ -13,5 +13,5 @@ dependencies:
   - bioconda::bioconductor-dnacopy=1.66.0
   - bioconda::bioconductor-variantannotation=1.38.0
   - bioconda::bioconductor-purecn=1.22.1
-  - bioconda::bcftools=1.10.2
-  - bioconda::tabix=0.2.6
+  - bioconda::bcftools>=1.10.2
+  - bioconda::tabix>=0.2.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Fixed:
 * Pip installation failure inside balsamic container #758
 * Fixed issue #768 with missing ``vep_install`` command in container
 * Fixed issue #765 with correct input bam files for SV rules
+* Locked version for ``cryptography`` package
 
 [8.1.0]
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed:
 * Fixed issue #768 with missing ``vep_install`` command in container
 * Fixed issue #765 with correct input bam files for SV rules
 * Locked version for ``cryptography`` package
+* Bumped version for ``bcftools`` in cnvkit container
 
 [8.1.0]
 -------

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "h5py>=3.1.0",
         "PyPDF2>=1.26.0",
         "markdown==3.3.3",
-        "cryptography<3.4",
+        "cryptography==3.2.1",
     ],
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
### This PR:

Lock `cryptography` package version.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
