### PR TITLE
fix: container master status docker badge 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Fixed:
 * Fixed missing output option in bcftools filters for tnhaplotyper #793 
 * Fixed issue #795 with increasing resources for vep and filter SV prior to vep
 * Building ``wheel`` for ``cryptography`` bug inside BALSAMIC container #801
+* Fixed badget for docker container master and develop status  
 
 [8.1.0]
 -------

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Snakemake cli given that there is a proper config file created.
      - |test_status_badge|
    * - Container latest release status
      - |docker_latest_release_status|
-   * - Container master status 
+   * - Container master and develop status 
      - |docker_latest_build_status|
    * - Code coverage
      - |code_cov_badge|_
@@ -54,7 +54,7 @@ Snakemake cli given that there is a proper config file created.
 
 .. |test_status_badge| image:: https://github.com/Clinical-Genomics/BALSAMIC/actions/workflows/pytest_and_coveralls.yml/badge.svg
 
-.. |docker_latest_build_status| image:: https://github.com/Clinical-Genomics/BALSAMIC/actions/workflows/docker_build_push_master.yml/badge.svg 
+.. |docker_latest_build_status| image:: https://github.com/Clinical-Genomics/BALSAMIC/actions/workflows/docker_build_push.yml/badge.svg 
 
 .. |docker_latest_release_status| image:: https://github.com/Clinical-Genomics/BALSAMIC/actions/workflows/docker_build_push_release.yml/badge.svg?tag=v8.1.0 
   


### PR DESCRIPTION
### This PR:
Fixed: Currently the docker badge for "Container master status" is shown as "Not found".
This PR fixes the correct URL path for displaying the badge "passing"


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
