### PR TITLE
fix: bumpversion for main Dockerfile

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,8 +6,6 @@ tag_name = v{new_version}
 
 [bumpversion:file:CITATION.cff]
 
-[bumpversion:file:Dockerfile]
-
 [bumpversion:file:BALSAMIC/__version__.py]
 
 [bumpversion:file:BALSAMIC/__init__.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,6 +6,8 @@ tag_name = v{new_version}
 
 [bumpversion:file:CITATION.cff]
 
+[bumpversion:file:BALSAMIC/containers/balsamic/Dockerfile]
+
 [bumpversion:file:BALSAMIC/__version__.py]
 
 [bumpversion:file:BALSAMIC/__init__.py]

--- a/BALSAMIC/containers/align_qc/Dockerfile
+++ b/BALSAMIC/containers/align_qc/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/BALSAMIC/containers/annotate/Dockerfile
+++ b/BALSAMIC/containers/annotate/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/BALSAMIC/containers/coverage_qc/Dockerfile
+++ b/BALSAMIC/containers/coverage_qc/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/BALSAMIC/containers/varcall_cnvkit/Dockerfile
+++ b/BALSAMIC/containers/varcall_cnvkit/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/BALSAMIC/containers/varcall_py27/Dockerfile
+++ b/BALSAMIC/containers/varcall_py27/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/BALSAMIC/containers/varcall_py36/Dockerfile
+++ b/BALSAMIC/containers/varcall_py36/Dockerfile
@@ -6,7 +6,6 @@ LABEL about.documentation="https://balsamic.readthedocs.io/"
 LABEL about.license="MIT License (MIT)"
 LABEL about.maintainer="Hassan Foroughi hassan dot foroughi at scilifelab dot se" 
 LABEL about.description="Bioinformatic analysis pipeline for somatic mutations in cancer"
-LABEL about.version="8.1.0"
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,8 @@ Fixed:
 * Fixed badget for docker container master and develop status  
 * ReadtheDocs building failure due to dependencies, fixed by locking versions #773
 * Dev requirements installation for Sphinx docs (Github Action) #812
+* Changed path for main Dockerfile version in ``.bumpversion.cfg``
+
 
 [8.1.0]
 -------


### PR DESCRIPTION
### This PR:

Fixed:
- bumpversion for main Dockerfile in `.bumpversion.cfg`

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
