### PR TITLE
fix: cnvkit gender comparison operator

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -130,7 +130,7 @@ if $purecn_status; then
 purity=$(awk -F\\, 'NR>1 {{print $2}}' {params.purecn_dir}/{params.sample_id}.csv)
 ploidy=$(awk -F\\, 'NR>1 {{printf int($3)}}' {params.purecn_dir}/{params.sample_id}.csv)
 gender=$(awk -F\\, 'NR>1 {{print $4}}' {params.purecn_dir}/{params.sample_id}.csv | tr '[:upper:]' '[:lower:]' | tr -d \\"); 
-if $gender="?"; then gender="x";fi
+if [ "$gender" = "?" ]; then gender="x"; fi
 fi
 
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -118,7 +118,7 @@ if $purecn_status; then
 purity=$(awk -F\\, 'NR>1 {{print $2}}' {params.purecn_dir}/{params.sample_id}.csv)
 ploidy=$(awk -F\\, 'NR>1 {{printf int($3)}}' {params.purecn_dir}/{params.sample_id}.csv)
 gender=$(awk -F\\, 'NR>1 {{print $4}}' {params.purecn_dir}/{params.sample_id}.csv | tr '[:upper:]' '[:lower:]' | tr -d \\")
-if $gender="?"; then gender="x"; fi
+if [ "$gender" = "?" ]; then gender="x"; fi
 fi
 
 # Call copy number variants from segmented log2 ratios

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+[8.2.1]
+-------
+
+Fixed:
+^^^^^^
+
+* ``cnvkit`` gender comparison operator bug #819
+
 [8.2.0]
 -------
 
@@ -53,8 +61,6 @@ Fixed:
 * ReadtheDocs building failure due to dependencies, fixed by locking versions #773
 * Dev requirements installation for Sphinx docs (Github Action) #812
 * Changed path for main Dockerfile version in ``.bumpversion.cfg``
-* ``cnvkit`` gender comparison operator bug #819
-
 
 [8.1.0]
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ Fixed:
 * ReadtheDocs building failure due to dependencies, fixed by locking versions #773
 * Dev requirements installation for Sphinx docs (Github Action) #812
 * Changed path for main Dockerfile version in ``.bumpversion.cfg``
+* ``cnvkit`` gender comparison operator bug #819
 
 
 [8.1.0]


### PR DESCRIPTION
### This PR:

Fixes the `cnvkit.py` call error made from `cnvkit_single.rule` and `cnvkit_paired.rule` during the validation of `BALSAMIC 8.2.0` on stage using the PANEL_UMI TUMOR_ONLY CASE (`uphippo`).

`uphippo` validation case log:

<img width="1146" alt="Screen Shot 2021-11-11 at 14 45 10" src="https://user-images.githubusercontent.com/26309194/141311186-9c8cb461-04b3-4059-871a-9b434718674c.png">

### Review and tests: 
- [x] Tests pass
- [x] Code review
- [x] New code is executed and covered by tests, and test approve