### PR TITLE
fix: cnvkit genderissue

### DIFF
--- a/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
+++ b/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
@@ -6,12 +6,12 @@ dependencies:
   - conda-forge::python=3.7
   - conda-forge::pip
   - conda-forge::r-base=4.1.0
-  - conda-forge::r-optparse=1.6.6
-  - bioconda::bioconductor-iranges=2.26.0
-  - bioconda::bioconductor-genomeinfodb=1.28.0
-  - bioconda::bioconductor-genomicranges=1.44.0
-  - bioconda::bioconductor-dnacopy=1.66.0
-  - bioconda::bioconductor-variantannotation=1.38.0
-  - bioconda::bioconductor-purecn=1.22.1
+  - conda-forge::r-optparse=1.7.1
+  - bioconda::bioconductor-iranges=2.28.0
+  - bioconda::bioconductor-genomeinfodb=1.30.0
+  - bioconda::bioconductor-genomicranges=1.46.1
+  - bioconda::bioconductor-dnacopy=1.68.0
+  - bioconda::bioconductor-variantannotation=1.40.0
+  - bioconda::bioconductor-purecn=2.0.1
   - bioconda::bcftools>=1.10.2
   - bioconda::tabix>=0.2.6

--- a/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
+++ b/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
@@ -13,5 +13,5 @@ dependencies:
   - bioconda::bioconductor-dnacopy=1.68.0
   - bioconda::bioconductor-variantannotation=1.40.0
   - bioconda::bioconductor-purecn=2.0.1
-  - bioconda::bcftools>=1.10.2
+  - bioconda::bcftools>=1.13
   - bioconda::tabix>=0.2.6

--- a/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
+++ b/BALSAMIC/containers/varcall_cnvkit/varcall_cnvkit.yaml
@@ -9,7 +9,7 @@ dependencies:
   - conda-forge::r-optparse=1.7.1
   - bioconda::bioconductor-iranges=2.28.0
   - bioconda::bioconductor-genomeinfodb=1.30.0
-  - bioconda::bioconductor-genomicranges=1.46.1
+  - bioconda::bioconductor-genomicranges=1.46.0
   - bioconda::bioconductor-dnacopy=1.68.0
   - bioconda::bioconductor-variantannotation=1.40.0
   - bioconda::bioconductor-purecn=2.0.1

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -130,7 +130,7 @@ if $purecn_status; then
 purity=$(awk -F\\, 'NR>1 {{print $2}}' {params.purecn_dir}/{params.sample_id}.csv)
 ploidy=$(awk -F\\, 'NR>1 {{printf int($3)}}' {params.purecn_dir}/{params.sample_id}.csv)
 gender=$(awk -F\\, 'NR>1 {{print $4}}' {params.purecn_dir}/{params.sample_id}.csv | tr '[:upper:]' '[:lower:]' | tr -d \\"); 
-if [ "$gender" = "?" ]; then gender="x"; fi
+if [[ "$gender" = "?" || "$gender" =~ "coverage" ]]; then gender="x"; fi
 fi
 
 

--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_single.rule
@@ -118,7 +118,7 @@ if $purecn_status; then
 purity=$(awk -F\\, 'NR>1 {{print $2}}' {params.purecn_dir}/{params.sample_id}.csv)
 ploidy=$(awk -F\\, 'NR>1 {{printf int($3)}}' {params.purecn_dir}/{params.sample_id}.csv)
 gender=$(awk -F\\, 'NR>1 {{print $4}}' {params.purecn_dir}/{params.sample_id}.csv | tr '[:upper:]' '[:lower:]' | tr -d \\")
-if [ "$gender" = "?" ]; then gender="x"; fi
+if [[ "$gender" = "?" || "$gender" =~ "coverage" ]]; then gender="x"; fi
 fi
 
 # Call copy number variants from segmented log2 ratios

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+[X.X.X]
+-------
+Fixed:
+^^^^^^
+
+* Add default for gender if ``purecn`` captures dual gender values #824 
+
+Changed:
+^^^^^^^^
+* Updated ``purecn`` and its dependencies to latest versions 
+
 [8.2.2]
 -------
 Added:


### PR DESCRIPTION
### This PR:

Fixes #824 

- Possibility to report dual information about gender info in purecn/TUMOR.CSV file. Could be because of noisy data, contamination, loss of chrY, or misalignment of coverage and VCF.
- In such cases, consider gender as default `m`
- Updated `purecn` and its dependencies to latest versions. 


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
