### PR TITLE
refactor: umi intervalbed

### DIFF
--- a/BALSAMIC/constants/workflow_params.py
+++ b/BALSAMIC/constants/workflow_params.py
@@ -137,6 +137,7 @@ WORKFLOW_PARAMS = {
         "init_tumorLOD": 0.5,
         "error_rate": 5,
         "prunefactor": 3,
+        "padding": 20,
         "disable_detect": "sv",
     },
 }

--- a/BALSAMIC/constants/workflow_params.py
+++ b/BALSAMIC/constants/workflow_params.py
@@ -137,7 +137,7 @@ WORKFLOW_PARAMS = {
         "init_tumorLOD": 0.5,
         "error_rate": 5,
         "prunefactor": 3,
-        "padding": 20,
+        "padding": 100,
         "disable_detect": "sv",
     },
 }

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope.rule
@@ -27,6 +27,7 @@ rule sentieon_tnscope_umi:
         init_tumor_lod = params.tnscope_umi.init_tumorLOD,
         error_rate = params.tnscope_umi.error_rate,
         prune_factor = params.tnscope_umi.prunefactor,
+        padding = params.tnscope_umi.padding,
         tumor = "TUMOR",
         pcr_model = params.common.pcr_model
     threads: 
@@ -44,6 +45,8 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 -t {threads} \
 -r {input.ref_fa} \
 -i {input.bam} \
+--interval {input.bed} \
+--interval_padding {params.padding} \
 --algo {params.algo} \
 --tumor_sample {params.tumor} \
 --dbsnp {input.dbsnp} \

--- a/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope_tn.rule
+++ b/BALSAMIC/snakemake_rules/umi/sentieon_varcall_tnscope_tn.rule
@@ -28,6 +28,7 @@ rule sentieon_tnscope_umi_tn:
         error_rate = params.tnscope_umi.error_rate,
         prune_factor = params.tnscope_umi.prunefactor,
         pcr_model = params.common.pcr_model,
+        padding = params.tnscope_umi.padding,
         tumor = "TUMOR",
         normal = "NORMAL"
     threads: 
@@ -47,6 +48,8 @@ export SENTIEON_LICENSE={params.sentieon_lic};
 -r {input.ref_fa} \
 -i {input.bamT} \
 -i {input.bamN} \
+--interval {input.bed} \
+--interval_padding {params.padding} \
 --algo {params.algo} \
 --tumor_sample {params.tumor} \
 --normal_sample {params.normal} \

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -617,6 +617,7 @@ class UMIParamsTNscope(BaseModel):
         init_tumorLOD: float (required); minimum tumor log odds in the initial pass calling variants
         error_rate: int (required); allow error-rate to consider in calling
         prunefactor: int (required); pruning factor in the kmer graph
+        padding: int(required); amount to pad bed interval regions
     """
 
     algo: str
@@ -624,6 +625,7 @@ class UMIParamsTNscope(BaseModel):
     min_tumorLOD: int
     error_rate: int
     prunefactor: int
+    padding: int
     disable_detect: str
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+[X.X.X]
+-------
+
+Added:
+^^^^^^
+
+* Call umi variants using TNscope in bed defined regions #821
+
+
 [8.2.4]
 -------
 

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -365,6 +365,7 @@ def test_umiparams_tnscope():
     assert test_tnscope_params_built.disable_detect == "abc"
     assert test_tnscope_params_built.padding == 30
 
+
 def test_params_vardict():
     """test UMIParamsVardict model for correct validation"""
 

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -349,6 +349,7 @@ def test_umiparams_tnscope():
         "min_tumorLOD": 6,
         "error_rate": 5,
         "prunefactor": 3,
+        "padding": 30,
         "disable_detect": "abc",
     }
 
@@ -362,7 +363,7 @@ def test_umiparams_tnscope():
     assert test_tnscope_params_built.error_rate == 5
     assert test_tnscope_params_built.prunefactor == 3
     assert test_tnscope_params_built.disable_detect == "abc"
-
+    assert test_tnscope_params_built.padding == 30
 
 def test_params_vardict():
     """test UMIParamsVardict model for correct validation"""


### PR DESCRIPTION
### This PR:

While calling UMI variants using TNscope, use the panel-defined regions to restrict calls.
Fixes : #821


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
