### PR TITLE
refactor: update ascat, delly, manta, TNscope_umi and tnhaplotyper tags 

### DIFF
--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
@@ -84,8 +84,8 @@ rule bcftools_filter_TNscope_umi_tumor_normal:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.vcf.gz",
   output:
-    vcf_filtered_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
-    vcf_pass_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
+    vcf_filtered_TNscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
+    vcf_pass_TNscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_TNscope_umi_tumor_normal' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -102,11 +102,11 @@ rule bcftools_filter_TNscope_umi_tumor_normal:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered_tnscope_umi} -O z;
+| bcftools view -o {output.vcf_filtered_TNscope_umi} -O z;
 
-tabix -p vcf -f {output.vcf_filtered_tnscope_umi};
+tabix -p vcf -f {output.vcf_filtered_TNscope_umi};
 
-bcftools view -f PASS -o {output.vcf_pass_tnscope_umi} -O z {output.vcf_filtered_tnscope_umi};
+bcftools view -f PASS -o {output.vcf_pass_TNscope_umi} -O z {output.vcf_filtered_TNscope_umi};
 
-tabix -p vcf -f {output.vcf_pass_tnscope_umi};
+tabix -p vcf -f {output.vcf_pass_TNscope_umi};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
@@ -52,8 +52,8 @@ rule bcftools_filter_tnhaplotyper_tumor_normal:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
+    vcf_pass_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_tnhaplotyper_tumor_normal' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -70,13 +70,13 @@ rule bcftools_filter_tnhaplotyper_tumor_normal:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnhaplotyper} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnhaplotyper};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnhaplotyper} -O z {output.vcf_filtered_tnhaplotyper};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnhaplotyper};
     """
 
 
@@ -84,8 +84,8 @@ rule bcftools_filter_TNscope_umi_tumor_normal:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
+    vcf_pass_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_TNscope_umi_tumor_normal' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -102,11 +102,11 @@ rule bcftools_filter_TNscope_umi_tumor_normal:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnscope_umi} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnscope_umi};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnscope_umi} -O z {output.vcf_filtered_tnscope_umi};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnscope_umi};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_normal.rule
@@ -8,8 +8,8 @@ rule bcftools_filter_vardict_tumor_normal:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.pass.vcf.gz",
+    vcf_filtered_vardict = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.vcf.gz",
+    vcf_pass_vardict = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_vardict_tumor_normal_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -38,13 +38,13 @@ bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/AF <  {params.AF_max[0]}' --soft-filter '{params.AF_max[1]}' --mode '+' \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
 | bcftools filter --exclude 'INFO/STATUS ~ "germline/i"' --soft-filter '{params.possible_germline}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_vardict} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_vardict};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_vardict} -O z {output.vcf_filtered_vardict};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_vardict};
     """
 
 

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
@@ -82,8 +82,8 @@ rule bcftools_filter_TNscope_umi_tumor_only:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.vcf.gz",
   output:
-    vcf_filtered_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
-    vcf_pass_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
+    vcf_filtered_TNscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
+    vcf_pass_TNscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_TNscope_umi_tumor_only' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -100,11 +100,11 @@ rule bcftools_filter_TNscope_umi_tumor_only:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered_tnscope_umi} -O z;
+| bcftools view -o {output.vcf_filtered_TNscope_umi} -O z;
 
-tabix -p vcf -f {output.vcf_filtered_tnscope_umi};
+tabix -p vcf -f {output.vcf_filtered_TNscope_umi};
 
-bcftools view -f PASS -o {output.vcf_pass_tnscope_umi} -O z {output.vcf_filtered_tnscope_umi};
+bcftools view -f PASS -o {output.vcf_pass_TNscope_umi} -O z {output.vcf_filtered_TNscope_umi};
 
-tabix -p vcf -f {output.vcf_pass_tnscope_umi};
+tabix -p vcf -f {output.vcf_pass_TNscope_umi};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
@@ -8,8 +8,8 @@ rule bcftools_filter_vardict_tumor_only:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.pass.vcf.gz",
+    vcf_filtered_vardict = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.vcf.gz",
+    vcf_pass_vardict = vep_dir + "{var_type}.somatic.{case_name}.vardict.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_vardict_tumor_only_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -36,13 +36,13 @@ bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/AF >= {params.AF_min[0]}' --soft-filter '{params.AF_min[1]}' --mode '+' \
 | bcftools filter --include 'INFO/AF <  {params.AF_max[0]}' --soft-filter '{params.AF_max[1]}' --mode '+' \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_vardict} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_vardict};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_vardict} -O z {output.vcf_filtered_vardict};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_vardict};
     """
 
 

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_filter_tumor_only.rule
@@ -50,8 +50,8 @@ rule bcftools_filter_tnhaplotyper_tumor_only:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
+    vcf_pass_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_tnhaplotyper_tumor_only' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -68,13 +68,13 @@ rule bcftools_filter_tnhaplotyper_tumor_only:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnhaplotyper} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnhaplotyper};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnhaplotyper} -O z {output.vcf_filtered_tnhaplotyper};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnhaplotyper};
     """
 
 
@@ -82,8 +82,8 @@ rule bcftools_filter_TNscope_umi_tumor_only:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.vcf.gz",
+    vcf_pass_tnscope_umi = vep_dir + "{var_type}.somatic.{case_name}.TNscope_umi.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_TNscope_umi_tumor_only' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -100,11 +100,11 @@ rule bcftools_filter_TNscope_umi_tumor_only:
     """
 bcftools view {input.vcf} \
 | bcftools filter --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnscope_umi} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnscope_umi};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnscope_umi} -O z {output.vcf_filtered_tnscope_umi};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnscope_umi};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_sv_filter.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_sv_filter.rule
@@ -33,7 +33,7 @@ rule bcftools_filter_cnvkit:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.cnvkit.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "{var_type}.somatic.{case_name}.cnvkit.all.filtered.pass.vcf.gz",
+    vcf_cnv_pass = vep_dir + "{var_type}.somatic.{case_name}.cnvkit.all.filtered.pass.vcf.gz",
   benchmark:
     benchmark_dir + 'bcftools_filter_' + "{var_type}.somatic.{case_name}.cnvkit.vep.tsv"
   singularity:
@@ -47,8 +47,8 @@ rule bcftools_filter_cnvkit:
     "Filtering CNVkit results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_cnv_pass} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_cnv_pass};
     """
 
 

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_sv_filter.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_sv_filter.rule
@@ -7,11 +7,11 @@
 
 rule bcftools_filter_manta:
   input:
-    vcf = vep_dir + "{var_type}.somatic.{case_name}.manta.all.vcf.gz",
+    vcf = vep_dir + "SV.somatic.{case_name}.manta.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "{var_type}.somatic.{case_name}.manta.all.filtered.pass.vcf.gz",
+    vcf_sv_pass = vep_dir + "SV.somatic.{case_name}.manta.all.filtered.pass.vcf.gz",
   benchmark:
-    Path(benchmark_dir, 'bcftools_filter_manta_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
+    Path(benchmark_dir, 'bcftools_filter_manta_' + "SV.somatic.{case_name}.tsv").as_posix()
   singularity:
     Path(singularity_image, config["bioinfo_tools"].get("bcftools") + ".sif").as_posix() 
   params:
@@ -54,11 +54,11 @@ tabix -p vcf -f {output.vcf_sv_pass};
 
 rule bcftools_filter_delly:
   input:
-    vcf = vep_dir + "{var_type}.somatic.{case_name}.delly.all.vcf.gz",
+    vcf = vep_dir + "SV.somatic.{case_name}.delly.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "{var_type}.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
+    vcf_sv_pass_delly = vep_dir + "SV.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
   benchmark:
-    benchmark_dir + 'bcftools_filter_' + "{var_type}.somatic.{case_name}.delly.vep.tsv"
+    benchmark_dir + 'bcftools_filter_' + "SV.somatic.{case_name}.delly.vep.tsv"
   singularity:
     Path(singularity_image, config["bioinfo_tools"].get("bcftools") + ".sif").as_posix() 
   params:
@@ -70,6 +70,6 @@ rule bcftools_filter_delly:
     "Filtering Delly results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass_delly} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_sv_pass_delly};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_normal.rule
@@ -33,7 +33,7 @@ rule bcftools_filter_delly:
   input:
     vcf = vep_dir + "SV.somatic.{case_name}.delly.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "SV.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
+    vcf_sv_pass_delly = vep_dir + "SV.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
   benchmark:
     benchmark_dir + "bcftools_filter_delly_SV.somatic.{case_name}.delly.vep.tsv"
   singularity:
@@ -48,8 +48,8 @@ rule bcftools_filter_delly:
     "Filtering Delly results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass_delly} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_sv_pass_delly};
     """
 
 
@@ -57,7 +57,7 @@ rule bcftools_filter_ascat:
   input:
     vcf = vep_dir + "CNV.somatic.{case_name}.ascat.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "CNV.somatic.{case_name}.ascat.all.filtered.pass.vcf.gz",
+    vcf_sv_pass_ascat = vep_dir + "CNV.somatic.{case_name}.ascat.all.filtered.pass.vcf.gz",
   benchmark:
     benchmark_dir + "bcftools_filter_ascat_CNV.somatic.{case_name}.ascat.vep.tsv"
   singularity:
@@ -72,6 +72,6 @@ rule bcftools_filter_ascat:
     "Filtering Ascat results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass_ascat} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_sv_pass_ascat};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_normal.rule
@@ -57,7 +57,7 @@ rule bcftools_filter_ascat:
   input:
     vcf = vep_dir + "CNV.somatic.{case_name}.ascat.all.vcf.gz",
   output:
-    vcf_sv_pass_ascat = vep_dir + "CNV.somatic.{case_name}.ascat.all.filtered.pass.vcf.gz",
+    vcf_cnv_pass_ascat = vep_dir + "CNV.somatic.{case_name}.ascat.all.filtered.pass.vcf.gz",
   benchmark:
     benchmark_dir + "bcftools_filter_ascat_CNV.somatic.{case_name}.ascat.vep.tsv"
   singularity:
@@ -72,6 +72,6 @@ rule bcftools_filter_ascat:
     "Filtering Ascat results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass_ascat} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass_ascat};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_cnv_pass_ascat} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_cnv_pass_ascat};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_sv_wgs_filter_tumor_only.rule
@@ -33,7 +33,7 @@ rule bcftools_filter_delly:
   input:
     vcf = vep_dir + "SV.somatic.{case_name}.delly.all.vcf.gz",
   output:
-    vcf_sv_pass = vep_dir + "SV.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
+    vcf_sv_pass_delly = vep_dir + "SV.somatic.{case_name}.delly.all.filtered.pass.vcf.gz",
   benchmark:
     benchmark_dir + "bcftools_filter_delly_SV.somatic.{case_name}.delly.vep.tsv"
   singularity:
@@ -48,6 +48,6 @@ rule bcftools_filter_delly:
     "Filtering Delly results for PASS variants using bcftools for sample '{params.case_name}' "
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass} -O z {input.vcf};
-tabix -p vcf -f {output.vcf_sv_pass};
+bcftools view --threads {threads} -f .,PASS -o {output.vcf_sv_pass_delly} -O z {input.vcf};
+tabix -p vcf -f {output.vcf_sv_pass_delly};
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
@@ -49,8 +49,8 @@ rule bcftools_filter_tnhaplotyper_tumor_normal:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.vcf.gz",
     wgs_calling_file = config["reference"]["wgs_calling_interval"]
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
+    vcf_pass_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_tnhaplotyper_tumor_normal_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -69,11 +69,11 @@ grep -v '^@' {input.wgs_calling_file} > {input.wgs_calling_file}.bed
 
 bcftools view -f PASS --threads {threads} --regions-file {input.wgs_calling_file}.bed {input.vcf} \
 | bcftools filter --threads {threads} --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnhaplotyper} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnhaplotyper};
 
-bcftools view -f PASS --threads {threads} -O z -o {output.vcf_pass} {output.vcf_filtered}
+bcftools view -f PASS --threads {threads} -O z -o {output.vcf_pass_tnhaplotyper} {output.vcf_filtered_tnhaplotyper}
 
-tabix -p vcf -f {output.vcf_pass}
+tabix -p vcf -f {output.vcf_pass_tnhaplotyper}
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_normal.rule
@@ -8,8 +8,8 @@ rule bcftools_filter_tnscope_tumor_normal:
   input:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.vcf.gz",
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnscope = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.vcf.gz",
+    vcf_pass_tnscope = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_tnscope_tumor_normal_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -34,13 +34,13 @@ bcftools view {input.vcf} \
 | bcftools filter --threads {threads} --include 'FORMAT/AF[0] >= {params.AF_min[0]}' --soft-filter '{params.AF_min[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/AF[0] <  {params.AF_max[0]}' --soft-filter '{params.AF_max[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnscope} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnscope};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnscope} -O z {output.vcf_filtered_tnscope};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnscope};
     """
 
 

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
@@ -42,9 +42,9 @@ bcftools view -f PASS --threads {threads} --regions-file {input.wgs_calling_file
 | bcftools filter --threads {threads} --include 'SUM(FORMAT/QSS)/SUM(FORMAT/AD) >= {params.qss[0]}' --soft-filter '{params.qss[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/ALT_F1R2 > {params.strand_reads[0]} && (FORMAT/ALT_F1R2 > 0  && FORMAT/ALT_F2R1 > {params.strand_reads[0]} &&  FORMAT/REF_F1R2 > {params.strand_reads[0]} && FORMAT/REF_F2R1 > {params.strand_reads[0]})' --soft-filter '{params.strand_reads[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include "INFO/SOR < {params.sor[0]}" --soft-filter '{params.sor[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnscope} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnscope};
     """
 
 
@@ -100,8 +100,8 @@ rule bcftools_intersect_tumor_only:
     tnscope = vep_dir + "{var_type}.somatic.{case_name}.tnscope_isec.all.filtered.vcf.gz",
     tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz"
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnscope = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.vcf.gz",
+    vcf_pass_tnscope = vep_dir + "{var_type}.somatic.{case_name}.tnscope.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_intersect_tumor_only_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -118,13 +118,13 @@ rule bcftools_intersect_tumor_only:
     """
 bcftools isec {input.tnscope} {input.tnhaplotyper} -p {params.vcf_dir} -O z;
 
-cp {params.vcf_dir}/0002.vcf.gz {output.vcf_filtered};
+cp {params.vcf_dir}/0002.vcf.gz {output.vcf_filtered_tnscope};
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnscope};
 
-bcftools view -f PASS -o {output.vcf_pass} -O z {output.vcf_filtered};
+bcftools view -f PASS -o {output.vcf_pass_tnscope} -O z {output.vcf_filtered_tnscope};
 
-tabix -p vcf -f {output.vcf_pass};
+tabix -p vcf -f {output.vcf_pass_tnscope};
 
 rm -r {params.vcf_dir}         
     """

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
@@ -53,8 +53,8 @@ rule bcftools_filter_tnhaplotyper_tumor_only:
     vcf = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.vcf.gz",
     wgs_calling_file = config["reference"]["wgs_calling_interval"]
   output:
-    vcf_filtered = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
-    vcf_pass = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
+    vcf_filtered_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.vcf.gz",
+    vcf_pass_tnhaplotyper = vep_dir + "{var_type}.somatic.{case_name}.tnhaplotyper.all.filtered.pass.vcf.gz",
   benchmark:
     Path(benchmark_dir, 'bcftools_filter_tnhaplotyper_tumor_only_' + "{var_type}.somatic.{case_name}.tsv").as_posix()
   singularity:
@@ -85,13 +85,13 @@ bcftools view -f PASS --threads {threads} --regions-file {input.wgs_calling_file
 | bcftools filter --threads {threads} --include 'INFO/GNOMADAF_popmax <= {params.pop_freq[0]} || INFO/GNOMADAF_popmax == \".\"' --soft-filter '{params.pop_freq[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'SUM(FORMAT/QSS)/SUM(FORMAT/AD) >= {params.qss[0]}' --soft-filter '{params.qss[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/ALT_F1R2 > {params.strand_reads[0]} && (FORMAT/ALT_F1R2 > 0  && FORMAT/ALT_F2R1 > {params.strand_reads[0]} &&  FORMAT/REF_F1R2 > {params.strand_reads[0]} && FORMAT/REF_F2R1 > {params.strand_reads[0]})' --soft-filter '{params.strand_reads[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered} -O z;
+| bcftools view -o {output.vcf_filtered_tnhaplotyper} -O z;
 
-tabix -p vcf -f {output.vcf_filtered};
+tabix -p vcf -f {output.vcf_filtered_tnhaplotyper};
 
-bcftools view -f PASS --threads {threads} -O z -o {output.vcf_pass} {output.vcf_filtered}
+bcftools view -f PASS --threads {threads} -O z -o {output.vcf_pass_tnhaplotyper} {output.vcf_filtered_tnhaplotyper}
 
-tabix -p vcf -f {output.vcf_pass}
+tabix -p vcf -f {output.vcf_pass_tnhaplotyper}
     """
 
 

--- a/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/annotation/varcaller_wgs_filter_tumor_only.rule
@@ -42,9 +42,9 @@ bcftools view -f PASS --threads {threads} --regions-file {input.wgs_calling_file
 | bcftools filter --threads {threads} --include 'SUM(FORMAT/QSS)/SUM(FORMAT/AD) >= {params.qss[0]}' --soft-filter '{params.qss[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include 'FORMAT/ALT_F1R2 > {params.strand_reads[0]} && (FORMAT/ALT_F1R2 > 0  && FORMAT/ALT_F2R1 > {params.strand_reads[0]} &&  FORMAT/REF_F1R2 > {params.strand_reads[0]} && FORMAT/REF_F2R1 > {params.strand_reads[0]})' --soft-filter '{params.strand_reads[1]}' --mode '+' \
 | bcftools filter --threads {threads} --include "INFO/SOR < {params.sor[0]}" --soft-filter '{params.sor[1]}' --mode '+' \
-| bcftools view -o {output.vcf_filtered_tnscope} -O z;
+| bcftools view -o {output.vcf_filtered} -O z;
 
-tabix -p vcf -f {output.vcf_filtered_tnscope};
+tabix -p vcf -f {output.vcf_filtered};
     """
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changed:
 ^^^^^^^^
 
 * Merge QC metric extraction workflows #833
-* ``ascat``, ``delly``, ``manta``, ``cnvkit``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #849
+* ``ascat``, ``delly``, ``manta``, ``cnvkit``, ``TNscope_umi``, ``tnhaplotyper``, ``vardict``, ``tnscope`` filtered file tags #849
 
 Fixed:
 ^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changed:
 ^^^^^^^^
 
 * Merge QC metric extraction workflows #833
+* ``ascat``, ``delly``, ``manta``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #848
 
 Removed
 ^^^^^^^
@@ -20,6 +21,9 @@ Removed
 
 [8.2.5]
 -------
+
+Added:
+^^^^^^
 
 * balsamic.sif container installation during cache generation #841
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changed:
 ^^^^^^^^
 
 * Merge QC metric extraction workflows #833
-* ``ascat``, ``delly``, ``manta``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #848
+* ``ascat``, ``delly``, ``manta``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #849
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changed:
 ^^^^^^^^
 
 * Merge QC metric extraction workflows #833
-* ``ascat``, ``delly``, ``manta``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #849
+* ``ascat``, ``delly``, ``manta``, ``cnvkit``, ``TNscope_umi`` and ``tnhaplotyper`` filtered file tags #849
 
 Fixed:
 ^^^^^^


### PR DESCRIPTION
### This PR:

- Removes the additional `sv` tag for `delly` and `manta` filtered files when running targeted analysis.
- Adds specific tags to the filtered `delly` and `ascat` files to distinguish them at CG level.
- Adds specific tags to the filtered `TNscope_umi` and `tnhaplotyper` files.
- Change tag name `cnvkit`.
- Adds specific tags to the filtered `tnscope` and `vardict` files.


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve