### PR TITLE
fix: QC panel bed version generalisation

### DIFF
--- a/BALSAMIC/assets/scripts/collect_qc_metrics.py
+++ b/BALSAMIC/assets/scripts/collect_qc_metrics.py
@@ -96,15 +96,15 @@ def get_multiqc_data_source(multiqc_data: dict, sample: str, tool: str) -> str:
                     )
 
 
-def get_qc_available_panel_beds(metrics: List[str]) -> List[str]:
-    """Returns available panel bed file names from a list of requested metrics"""
-    available_beds = []
+def get_qc_supported_capture_kit(capture_kit, metrics: List[str]) -> str:
+    """Returns a BALSAMIC supported panel bed name associated to a specific capture_kit parameter"""
+    available_panel_beds = []
 
     for k in metrics:
         if k != "default":
-            available_beds.append(k)
+            available_panel_beds.append(k)
 
-    return available_beds
+    return next((i for i in available_panel_beds if i in capture_kit), None)
 
 
 def get_requested_metrics(
@@ -115,8 +115,11 @@ def get_requested_metrics(
     requested_metrics = metrics[sequencing_type]
     if capture_kit:
         requested_metrics = metrics[sequencing_type]["default"]
-        if capture_kit in get_qc_available_panel_beds(metrics[sequencing_type]):
-            requested_metrics.update(metrics[sequencing_type][capture_kit])
+        supported_capture_kit = get_qc_supported_capture_kit(
+            capture_kit, metrics[sequencing_type]
+        )
+        if supported_capture_kit:
+            requested_metrics.update(metrics[sequencing_type][supported_capture_kit])
 
     return requested_metrics
 

--- a/BALSAMIC/constants/quality_check_reporting.py
+++ b/BALSAMIC/constants/quality_check_reporting.py
@@ -55,14 +55,14 @@ METRICS = {
         "default": {
             "MEAN_INSERT_SIZE": {"condition": None},
             "PERCENT_DUPLICATION": {"condition": None},
-            "MEDIAN_TARGET_COVERAGE": {"condition": None},
+            "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 500}},
             "PCT_TARGET_BASES_50X": {"condition": None},
             "PCT_TARGET_BASES_100X": {"condition": None},
             "PCT_TARGET_BASES_250X": {"condition": None},
             "PCT_TARGET_BASES_500X": {"condition": None},
             "PCT_TARGET_BASES_1000X": {"condition": None},
             "MEAN_TARGET_COVERAGE": {"condition": None},
-            "FOLD_80_BASE_PENALTY": {"condition": None},
+            "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.8}},
             "PCT_OFF_BAIT": {"condition": None},
         },
         "gicfdna": {

--- a/BALSAMIC/constants/quality_check_reporting.py
+++ b/BALSAMIC/constants/quality_check_reporting.py
@@ -65,27 +65,27 @@ METRICS = {
             "FOLD_80_BASE_PENALTY": {"condition": None},
             "PCT_OFF_BAIT": {"condition": None},
         },
-        "gicfdna_3.1_hg19_design.bed": {
+        "gicfdna": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 1000}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.6}},
         },
-        "gmcksolid_4.1_hg19_design.bed": {
+        "gmcksolid": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 500}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.8}},
         },
-        "gmsmyeloid_5.2_hg19_design.bed": {
+        "gmsmyeloid": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 1000}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.6}},
         },
-        "lymphoma_6.1_hg19_design.bed": {
+        "lymphoma": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 1000}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.6}},
         },
-        "gmslymphoid_7.1_hg19_design.bed": {
+        "gmslymphoid": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 1000}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.6}},
         },
-        "twistexomerefseq_9.1_hg19_design.bed": {
+        "twistexome": {
             "MEDIAN_TARGET_COVERAGE": {"condition": {"norm": "gt", "threshold": 100}},
             "FOLD_80_BASE_PENALTY": {"condition": {"norm": "lt", "threshold": 1.8}},
         },

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Added:
 * Snakemake workflow to create canfam3 reference #843
 * Call umi variants using TNscope in bed defined regions #821
 * UMI duplication metrics to report in multiqc_picard_dups.json #844
+* QC default validation conditions (for not defined capture kits) #855
 
 Changed:
 ^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,9 @@ Changed:
 
 Fixed:
 ^^^^^^
+
 * ``collect_qc_metrics.py`` failing for WGS cases with empty ``capture_kit`` argument #850
+* QC metric validation for different panel bed version #855
 
 Removed
 ^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,10 +518,10 @@ def qc_requested_metrics():
                 "METRIC_1": {"condition": None},
                 "METRIC_2": {"condition": {"norm": "gt", "threshold": 2}},
             },
-            "panel_1.bed": {
+            "panel_1": {
                 "METRIC_3": {"condition": {"norm": "gt", "threshold": 3}},
             },
-            "panel_2.bed": {
+            "panel_2": {
                 "METRIC_1": {"condition": {"norm": "gt", "threshold": 1}},
                 "METRIC_4": {"condition": {"norm": "gt", "threshold": 4}},
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -523,6 +523,7 @@ def qc_requested_metrics():
             },
             "panel_2": {
                 "METRIC_1": {"condition": {"norm": "gt", "threshold": 1}},
+                "METRIC_2": {"condition": {"norm": "gt", "threshold": 22}},
                 "METRIC_4": {"condition": {"norm": "gt", "threshold": 4}},
             },
         },

--- a/tests/scripts/test_collect_qc_metrics.py
+++ b/tests/scripts/test_collect_qc_metrics.py
@@ -5,7 +5,7 @@ from BALSAMIC.assets.scripts.collect_qc_metrics import (
     get_multiqc_data_source,
     get_multiqc_metrics,
     collect_qc_metrics,
-    get_qc_available_panel_beds,
+    get_qc_supported_capture_kit,
     get_requested_metrics,
     capture_kit_resolve_type,
 )
@@ -15,24 +15,29 @@ def test_capture_kit_resolve_type():
     """test capture_kit type"""
 
     # GIVEN an expected output
-    capture_kit = "panel.bed"
+    capture_kit = "panel_1_v1.0_hg19_design.bed"
 
     # THEN check if the extracted capture kit is correctly formatted
     assert capture_kit_resolve_type("None") is None
     assert capture_kit_resolve_type(capture_kit) == capture_kit
 
 
-def test_get_qc_available_panel_beds(qc_requested_metrics):
-    """test extraction of capture kits available for analysis"""
+def test_get_qc_supported_capture_kit(qc_requested_metrics):
+    """test extraction of the capture kit name available for analysis"""
+
+    # GIVEN a capture kit
+    capture_kit = "panel_1_v1.0_hg19_design.bed"
 
     # GIVEN an expected output
-    expected_output = ["panel_1.bed", "panel_2.bed"]
+    expected_output = "panel_1"
 
     # WHEN calling the function
-    available_panel_beds = get_qc_available_panel_beds(qc_requested_metrics["targeted"])
+    supported_capture_kit = get_qc_supported_capture_kit(
+        capture_kit, qc_requested_metrics["targeted"]
+    )
 
-    # THEN check if the extracted bed file names correspond to the expected ones
-    assert available_panel_beds == expected_output
+    # THEN check if the extracted bed file name corresponds to the expected one
+    assert supported_capture_kit == expected_output
 
 
 def test_get_requested_metrics_targeted(qc_requested_metrics):
@@ -40,7 +45,7 @@ def test_get_requested_metrics_targeted(qc_requested_metrics):
 
     # GIVEN a sequencing type and a capture kit
     seq_type = "targeted"
-    capture_kit = "panel_1.bed"
+    capture_kit = "panel_1_v1.0_hg19_design.bed"
 
     # GIVEN the expected output
     expected_output = {

--- a/tests/scripts/test_collect_qc_metrics.py
+++ b/tests/scripts/test_collect_qc_metrics.py
@@ -15,7 +15,7 @@ def test_capture_kit_resolve_type():
     """test capture_kit type"""
 
     # GIVEN an expected output
-    capture_kit = "panel_1_v1.0_hg19_design.bed"
+    capture_kit = "panel.bed"
 
     # THEN check if the extracted capture kit is correctly formatted
     assert capture_kit_resolve_type("None") is None

--- a/tests/scripts/test_collect_qc_metrics.py
+++ b/tests/scripts/test_collect_qc_metrics.py
@@ -45,13 +45,13 @@ def test_get_requested_metrics_targeted(qc_requested_metrics):
 
     # GIVEN a sequencing type and a capture kit
     seq_type = "targeted"
-    capture_kit = "panel_1_v1.0_hg19_design.bed"
+    capture_kit = "panel_2_v1.0_hg19_design.bed"
 
     # GIVEN the expected output
     expected_output = {
-        "METRIC_1": {"condition": None},
-        "METRIC_2": {"condition": {"norm": "gt", "threshold": 2}},
-        "METRIC_3": {"condition": {"norm": "gt", "threshold": 3}},
+        "METRIC_1": {"condition": {"norm": "gt", "threshold": 1}},
+        "METRIC_2": {"condition": {"norm": "gt", "threshold": 22}},
+        "METRIC_4": {"condition": {"norm": "gt", "threshold": 4}},
     }
 
     # WHEN calling the function


### PR DESCRIPTION
### This PR:

Fixes #854.

### Review and tests: 

- Condition (`METRIC` constant):
<img width="636" alt="Screen Shot 2022-02-04 at 14 47 42" src="https://user-images.githubusercontent.com/26309194/152540628-e62ee821-65cb-46e3-8191-cc6ff4c5123e.png">

- Extracted metrics (`<case_id>_metrics_deliverables.yaml`):
<img width="342" alt="Screen Shot 2022-02-04 at 14 43 30" src="https://user-images.githubusercontent.com/26309194/152540783-f8ae3da0-103a-4b48-b019-66ee4a846596.png">
<img width="349" alt="Screen Shot 2022-02-04 at 14 43 15" src="https://user-images.githubusercontent.com/26309194/152540778-3426827f-fcc9-4ea2-b0f2-0d792b7545aa.png">

- Validation successfully fails for the `panel.bed` test file (BALSAMIC.TN_panel.all.0.sh_<job_id>.err):
<img width="1143" alt="Screen Shot 2022-02-04 at 14 51 31" src="https://user-images.githubusercontent.com/26309194/152541108-3da4538e-b4e2-48c2-b014-9db57e07bc4d.png">

