### PR TITLE
fix: balsamic low vaf

### DIFF
--- a/BALSAMIC/constants/variant_filters.py
+++ b/BALSAMIC/constants/variant_filters.py
@@ -20,7 +20,7 @@ VARDICT_SETTINGS = {
     },
     "MQ": {"tag_value": 40, "filter_name": "balsamic_low_mq", "field": "INFO"},
     "AF_max": {"tag_value": 1, "filter_name": "balsamic_af_one", "field": "INFO"},
-    "AF_min": {"tag_value": 0.01, "filter_name": "balsamic_low_af", "field": "INFO"},
+    "AF_min": {"tag_value": 0.007, "filter_name": "balsamic_low_af", "field": "INFO"},
     "pop_freq": {
         "tag_value": 0.005,
         "filter_name": "balsamic_high_pop_freq",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changed:
 * Updated the bioinfo tools version numbers in BALSAMIC readthedocs #867
 * Sphinx version fixed to <0.18 #874
 * Sphinx GitHub action triggers only on master branch PRs
+* VAF filter for reporting somatic variants (Vardict) is minimised to 0.7% from 1% #876
 
 [8.2.7]
 -------

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Snakemake cli given that there is a proper config file created.
    * - Dependencies
      - |snakemake_badge| |singularity_badge|
    * - Contributors
-     - @ashwini06 , @mropat , @imsarath , @keyvanelhami
+     - @ashwini06, @ivadym, @khurrammaqbool, @keyvanelhami, @mropat, @imsarath
 
 
 .. |code_cov_badge| image:: https://codecov.io/gh/Clinical-Genomics/BALSAMIC/branch/develop/graph/badge.svg?token=qP68U3PNwV 

--- a/docs/balsamic_filters.rst
+++ b/docs/balsamic_filters.rst
@@ -19,7 +19,9 @@ For example:
 In the VCF file, `FILTER` status is `PASS` if this position has passed all filters, i.e., a call is made at this position. Otherwise,
 if the site has not passed all filters, a semicolon-separated list of codes for filters that fail. e.g., `p8;pSTD` might
 indicate that at this site, the mean position in reads is less than 8 and position in reads has a standard deviation of 0.
-In BALSAMIC, this VCF file is named as `*.all.vcf.gz` (eg: `SNV.somatic.<CASE_ID>.vardict.all.vcf.gz`)
+
+.. important::
+    In BALSAMIC, this VCF file is named as `*.all.vcf.gz` (eg: `SNV.somatic.<CASE_ID>.vardict.all.vcf.gz`)
 
 ..  figure:: images/filter_status.png
     :width: 500px
@@ -30,7 +32,9 @@ In BALSAMIC, this VCF file is named as `*.all.vcf.gz` (eg: `SNV.somatic.<CASE_ID
 
 For `Post-call filtering`, in BALSAMIC we have applied various filtering criteria (`Vardict_filtering`_, `TNscope filtering (Tumor_normal)`_ ) depending on the analysis-type (TGS/WGS) and sample-type(tumor-only/tumor-normal).
 
-In BALSAMIC, this VCF file is named as `*.all.filtered.pass.vcf.gz` (eg: `SNV.somatic.<CASE_ID>.vardict.all.filtered.pass.vcf.gz`)
+.. important::
+
+    In BALSAMIC, this VCF file is named as `*.all.filtered.pass.vcf.gz` (eg: `SNV.somatic.<CASE_ID>.vardict.all.filtered.pass.vcf.gz`)
 
 **Targeted Genome Analysis**
 #############################
@@ -72,8 +76,12 @@ Following are the set of criterias applied for filtering vardict results. Applie
 
 ::
 
-    Minimum AF >= 0.01
+    Minimum AF >= 0.007
     Maximum AF < 1
+
+.. attention::
+
+    BALSAMIC <= v8.2.7 uses minimum AF 1% (0.01). From Balsamic v8.2.8, minimum VAF is changed to 0.7% (0.007)
 
 *GNOMADAF_POPMAX*: Maximum Allele Frequency across populations
 
@@ -81,7 +89,9 @@ Following are the set of criterias applied for filtering vardict results. Applie
 
     GNOMADAF_popmax <= 0.005  (or) GNOMADAF_popmax == "."
 
-*Additionally, for tumor-normal cases; the variant is excluded if it marked as 'germline' in the `STATUS` column of vcf file.*
+.. important::
+
+    Additionally, for tumor-normal cases; the variant is excluded if it marked as 'germline' in the `STATUS` column of vcf file.
 
 **Whole Genome Sequencing (WGS)**
 **********************************

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -2,7 +2,7 @@
 Short tutorial
 ==============
 
-Here a short toturial is provided for BALSAMIC (**version** = 8.2.7). 
+Here a short tutorial is provided for BALSAMIC (**version** = 8.2.7).
 
 Running a test sample
 ---------------------


### PR DESCRIPTION
### This PR:

Changed: 
Filter for reporting somatic variants (Vardict) VAF is minimised to 0.7% from 1%. Related to https://github.com/Clinical-Genomics/project-planning/issues/377#issuecomment-1060291718
Updated the balsamic documents for variant calling filters and balsamic repo contributors


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
