### PR TITLE
fix: docs importing C dependant libraries

### DIFF
--- a/.github/workflows/sphinx_docs.yml
+++ b/.github/workflows/sphinx_docs.yml
@@ -18,5 +18,5 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "pip install -r requirements-dev.txt"
+          pre-build-command: "pip install -r requirements-dev.txt && python setup.py install"
           build-command: "sphinx-build -T -E -b html -d _build/doctrees-readthedocs -D language=en . _build/html"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Changed:
 * Sphinx version fixed to <0.18 #874
 * Sphinx GitHub action triggers only on master branch PRs
 
+Fixes:
+^^^^^^
+* numpy mock import for READTHEDOCS environment #874
+
 [8.2.7]
 -------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# Modules to be mocked up
+autodoc_mock_imports = ["numpy"]
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, "BALSAMIC", "__version__.py")) as f:
     exec(f.read(), about)
 
 # Requirements
-install_requires = [
+requirements = [
     "click>=7.1.2",
     "colorclass>=2.2.0",
     "coloredlogs>=14.0",
@@ -35,7 +35,7 @@ install_requires = [
 
 # The C libraries required to build numpy are not available on RTD
 if not os.getenv("READTHEDOCS"):
-    install_requires.append(
+    requirements.append(
         "numpy>=1.19.2",
     )
 
@@ -45,7 +45,7 @@ setup(
     url="https://github.com/Clinical-Genomics/BALSAMIC",
     author="Hassan Foroughi Asl",
     author_email="hassan.foroughi@scilifelab.se",
-    install_requires=install_requires,
+    install_requires=requirements,
     packages=find_packages(),
     package_data={
         "": [

--- a/setup.py
+++ b/setup.py
@@ -8,36 +8,44 @@ about = {}
 with open(os.path.join(here, "BALSAMIC", "__version__.py")) as f:
     exec(f.read(), about)
 
+# Requirements
+install_requires = [
+    "click>=7.1.2",
+    "colorclass>=2.2.0",
+    "coloredlogs>=14.0",
+    "cyvcf2<0.10.0",
+    "graphviz==0.16",
+    "gsutil==4.50",
+    "jinja2>=2.11.2",
+    "matplotlib>=3.3.0",
+    "networkx>=2.4",
+    "pandas>1.1.0",
+    "psutil>=5.7.0",
+    "pydantic>=1.5.1",
+    "pygments>=2.6.1",
+    "pyyaml>=5.3.1",
+    "six>=1.12.0",
+    "snakemake==6.5.3",
+    "yapf>=0.30.0",
+    "h5py>=3.1.0",
+    "PyPDF2>=1.26.0",
+    "markdown==3.3.3",
+    "cryptography==3.2.1",
+]
+
+# The C libraries required to build numpy are not available on RTD
+if not os.getenv("READTHEDOCS"):
+    install_requires.append(
+        "numpy>=1.19.2",
+    )
+
 setup(
     name="BALSAMIC",
     version=about["__version__"],
     url="https://github.com/Clinical-Genomics/BALSAMIC",
     author="Hassan Foroughi Asl",
     author_email="hassan.foroughi@scilifelab.se",
-    install_requires=[
-        "click>=7.1.2",
-        "colorclass>=2.2.0",
-        "coloredlogs>=14.0",
-        "cyvcf2<0.10.0",
-        "graphviz==0.16",
-        "gsutil==4.50",
-        "jinja2>=2.11.2",
-        "matplotlib>=3.3.0",
-        "networkx>=2.4",
-        "numpy>=1.19.2",
-        "pandas>1.1.0",
-        "psutil>=5.7.0",
-        "pydantic>=1.5.1",
-        "pygments>=2.6.1",
-        "pyyaml>=5.3.1",
-        "six>=1.12.0",
-        "snakemake==6.5.3",
-        "yapf>=0.30.0",
-        "h5py>=3.1.0",
-        "PyPDF2>=1.26.0",
-        "markdown==3.3.3",
-        "cryptography==3.2.1",
-    ],
+    install_requires=install_requires,
     packages=find_packages(),
     package_data={
         "": [


### PR DESCRIPTION
### This PR:

Adresses `ModuleNotFoundError: No module named 'numpy'` when building the docs:
https://readthedocs.org/projects/balsamic/builds/16287901/

Solution from:
https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
