### PR TITLE
fix: dock build mocking cyvcf dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -11,9 +16,8 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Requirements to build the docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements-dev.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changed:
 
 Fixes:
 ^^^^^^
-* numpy mock import for READTHEDOCS environment #874
+* cyvcf2 mock import for READTHEDOCS environment #874
 
 [8.2.7]
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # Modules to be mocked up
-autodoc_mock_imports = ["numpy"]
+autodoc_mock_imports = ["cyvcf2"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ requirements = [
     "click>=7.1.2",
     "colorclass>=2.2.0",
     "coloredlogs>=14.0",
-    "cyvcf2<0.10.0",
     "graphviz==0.16",
     "gsutil==4.50",
     "jinja2>=2.11.2",
     "matplotlib>=3.3.0",
     "networkx>=2.4",
+    "numpy>=1.19.2",
     "pandas>1.1.0",
     "psutil>=5.7.0",
     "pydantic>=1.5.1",
@@ -35,9 +35,7 @@ requirements = [
 
 # The C libraries required to build numpy are not available on RTD
 if not os.getenv("READTHEDOCS"):
-    requirements.append(
-        "numpy>=1.19.2",
-    )
+    requirements.extend(["cyvcf2<0.10.0"])
 
 setup(
     name="BALSAMIC",


### PR DESCRIPTION
### This PR:

Mocks cyvcf2 import  to build documentation.


Tested successfully in a fork repository ([ivadym/BALSAMIC](https://github.com/ivadym/BALSAMIC)):
https://readthedocs.org/projects/balsamic-docs/builds/16310624/

### Review and tests: 
- [x] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
