### PR TITLE
fix: change default fastp n_base_limit settings 

### DIFF
--- a/BALSAMIC/snakemake_rules/quality_control/fastp.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/fastp.rule
@@ -6,7 +6,7 @@ if 'quality_trim' in config['QC'].keys():
     fastp_param_adapter = list()
     fastp_param_umi = list()
     if config['QC']['quality_trim']:
-        fastp_param_qc.extend(["--trim_tail1", "1", "--n_base_limit", "5",
+        fastp_param_qc.extend(["--trim_tail1", "1", "--n_base_limit", "50",
                             "--length_required", config["QC"]["min_seq_length"],
                             "--low_complexity_filter", "--trim_poly_g"])
     else:

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -90,6 +90,7 @@ class QCModel(BaseModel):
         umi_trim : Field(bool); whether UMI trimming is to be performed in the workflow
         min_seq_length : Field(str(int)); minimum sequence length cutoff for reads
         umi_trim_length : Field(str(int)); length of UMI to be trimmed from reads
+        n_base_limit : Field(str(int)); supports filtering by limiting the N base number
 
     Raises:
         ValueError:
@@ -105,8 +106,9 @@ class QCModel(BaseModel):
     umi_trim: bool = False
     min_seq_length: int = 25
     umi_trim_length: int = 5
+    n_base_limit: int = 50
 
-    @validator("min_seq_length", "umi_trim_length")
+    @validator("min_seq_length", "umi_trim_length", "n_base_limit")
     def coerce_int_as_str(cls, value):
         return str(value)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-[X.X.X]
+[8.2.9]
 -------
 
 
@@ -6,7 +6,7 @@ Added:
 ^^^^^^
 * Added slurm qos tag `express` #885
 * Included more text about UMI-workflow variant calling settings to the readthedocs #888
-
+* Extend QCModel to include `n_base_limit` which outputs in config json `QC` dict
 
 Fixes:
 ^^^^^^
@@ -14,8 +14,8 @@ Fixes:
 
 Changed:
 ^^^^^^^^
-Upgrade black to 22.3.0
-
+* Upgrade black to 22.3.0
+* fastp default setting of `n_base_limit` is changed to `50` from `5`
 
 
 [8.2.8]
@@ -48,7 +48,6 @@ Fixes:
 
 [8.2.7]
 -------
-
 Fixes:
 ^^^^^^
 * Fixes fastqc timeout issues for wgs cases #861

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,6 @@
 [8.2.9]
 -------
 
-
 Added:
 ^^^^^^
 * Added slurm qos tag `express` #885
@@ -16,7 +15,6 @@ Changed:
 ^^^^^^^^
 * Upgrade black to 22.3.0
 * fastp default setting of `n_base_limit` is changed to `50` from `5`
-
 
 [8.2.8]
 -------

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -232,7 +232,12 @@ def test_varcallerfilter():
 def test_qc_model():
     # GIVEN valid input arguments
     # THEN we can successully create a config dict
-    valid_args = {"umi_trim": True, "min_seq_length": 25, "umi_trim_length": 5}
+    valid_args = {
+        "umi_trim": True,
+        "min_seq_length": 25,
+        "umi_trim_length": 5,
+        "n_base_limit": 50,
+    }
     assert QCModel.parse_obj(valid_args)
 
 


### PR DESCRIPTION
### This PR:

Fixes: #904 

Added: 
- Extended the QCModel to include `n_base_limit` which outputs in config json `QC` dict

<img width="581" alt="Screenshot 2022-04-06 at 11 29 12" src="https://user-images.githubusercontent.com/6302819/161944098-44fe44c2-853a-4038-9dc7-4e43dfd42e84.png">


### Review and tests: 
- [x] Tests pass
- [ ] Code review
- [x] New code is executed and covered by tests, and test approved
