### PR TITLE
fix: missing genderChr flag for ascat

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -179,6 +179,7 @@ if [[ "{params.gender}" = "female" ]]; then gender="XX"; else gender="XY"; fi
 ascat.pl \
   -protocol WGS \
   -species human \
+  -genderChr Y \
   -assembly {params.genome} \
   -cpus {threads} \
   -reference {input.fa} \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Added:
 * SV and CNV analysis and `TIDDIT` to balsamic ReadtheDocs https://github.com/Clinical-Genomics/BALSAMIC/pull/951
 * Gender to `config.json` https://github.com/Clinical-Genomics/BALSAMIC/pull/955
 * Provided gender as input for `vcf2cyosure` https://github.com/Clinical-Genomics/BALSAMIC/pull/955
-* Germline normal SNV VCF file header renaming to be compatible with genotype uploads https://github.com/Clinical-Genomics/BALSAMIC/issues/882 
+* Germline normal SNV VCF file header renaming to be compatible with genotype uploads https://github.com/Clinical-Genomics/BALSAMIC/issues/882
 
 Changed:
 ^^^^^^^^
@@ -35,6 +35,7 @@ Fixed:
 * GENOME_VERSION set to the different genome_version options and replaced with config["reference"]["genome_version"] https://github.com/Clinical-Genomics/BALSAMIC/pull/942
 * `run_validate.sh` script https://github.com/Clinical-Genomics/BALSAMIC/pull/952
 * Somatic SV tumor normal rules https://github.com/Clinical-Genomics/BALSAMIC/pull/959
+* Missing `genderChr` flag for `ascat_tumor_normal` rule https://github.com/Clinical-Genomics/BALSAMIC/pull/963
 
 Removed
 ^^^^^^^


### PR DESCRIPTION
### This PR:

Fixed:
- Missing `genderChr` flag for `ascat_tumor_normal` rule

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
