### PR TITLE
fix:  missing name `analysis_dir` in qc workflow

### DIFF
--- a/BALSAMIC/workflows/QC.smk
+++ b/BALSAMIC/workflows/QC.smk
@@ -35,7 +35,7 @@ tmp_dir = os.path.join(get_result_dir(config), "tmp", "" )
 Path.mkdir(Path(tmp_dir), exist_ok=True)
 
 case_id = config["analysis"]["case_id"]
-analysis_dir = config["analysis"]["analysis_dir"] + "/" +case_id + "/"
+analysis_dir = config["analysis"]["analysis_dir"] + "/" + case_id + "/"
 benchmark_dir = config["analysis"]["benchmark"]
 fastq_dir = get_result_dir(config) + "/fastq/"
 bam_dir = get_result_dir(config) + "/bam/"

--- a/BALSAMIC/workflows/QC.smk
+++ b/BALSAMIC/workflows/QC.smk
@@ -34,6 +34,8 @@ logging.getLogger("filelock").setLevel("WARN")
 tmp_dir = os.path.join(get_result_dir(config), "tmp", "" )
 Path.mkdir(Path(tmp_dir), exist_ok=True)
 
+case_id = config["analysis"]["case_id"]
+analysis_dir = config["analysis"]["analysis_dir"] + "/" +case_id + "/"
 benchmark_dir = config["analysis"]["benchmark"]
 fastq_dir = get_result_dir(config) + "/fastq/"
 bam_dir = get_result_dir(config) + "/bam/"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Fixed:
 * Somatic SV tumor normal rules https://github.com/Clinical-Genomics/BALSAMIC/pull/959
 * Missing `genderChr` flag for `ascat_tumor_normal` rule https://github.com/Clinical-Genomics/BALSAMIC/pull/963
 * Command in vcf2cytosure rule and updated ReadtheDocs https://github.com/Clinical-Genomics/BALSAMIC/pull/966
-* Missing name `analysis_dir` in QC.smk
+* Missing name `analysis_dir` in QC.smk https://github.com/Clinical-Genomics/BALSAMIC/pull/970
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Fixed:
 * Somatic SV tumor normal rules https://github.com/Clinical-Genomics/BALSAMIC/pull/959
 * Missing `genderChr` flag for `ascat_tumor_normal` rule https://github.com/Clinical-Genomics/BALSAMIC/pull/963
 * Command in vcf2cytosure rule and updated ReadtheDocs https://github.com/Clinical-Genomics/BALSAMIC/pull/966
+* Missing name `analysis_dir` in QC.smk
 
 Removed
 ^^^^^^^


### PR DESCRIPTION
### This PR:

`analysis_dir` is not defined in the QC.smk. Failed to create `balsamic config case ` with `-w balsamic-qc` option.
More details in the screenshot 

<img width="1385" alt="Screenshot 2022-06-25 at 14 51 31" src="https://user-images.githubusercontent.com/6302819/175825731-12495a69-54a9-45ab-b73c-66e2bc616631.png">


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
