### PR TITLE
fix: tiddit delivery rule names

### DIFF
--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -200,7 +200,7 @@
 		"time": "2:00:00",
 		"n": 8
 	},
-	"bcftools_query_calculatenoiseAF_umi": { 
+	"bcftools_query_calculatenoiseAF_umi": {
 		"time": "2:00:00",
 		"n": 8
 	},
@@ -232,11 +232,11 @@
 		"time": "02:00:00",
 		"n": 8
 	},
-	"tiddit_tumor_only": {
+	"tiddit_sv_tumor_only": {
 		"time": "10:00:00",
 		"n": 24
 	},
-	"tiddit_tumor_normal": {
+	"tiddit_sv_tumor_normal": {
 		"time": "12:00:00",
 		"n": 24
 	},

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -237,7 +237,7 @@ rule ascat_tumor_normal_merge_output:
 python {params.merge_ascat_output_script} {output.ascat_pdf} {input.sample_statistics} {input.ascat_plots}
         """
 
-rule tiddit_tumor_normal:
+rule tiddit_sv_tumor_normal:
     input:
         fa = config["reference"]["reference_genome"],
         bamN = bam_dir + normal_bam,
@@ -248,7 +248,7 @@ rule tiddit_tumor_normal:
         cov_normal_tiddit = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".normal.tiddit_cov.bed",
         namemap= vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".tiddit.sample_name_map",
     benchmark:
-        benchmark_dir + 'tiddit_tumor_normal_' + config["analysis"]["case_id"] + ".tsv"
+        benchmark_dir + 'tiddit_sv_tumor_normal_' + config["analysis"]["case_id"] + ".tsv"
     singularity:
         Path(singularity_image, config["bioinfo_tools"].get("tiddit") + ".sif").as_posix()
     params:
@@ -258,7 +258,7 @@ rule tiddit_tumor_normal:
         normal = "NORMAL",
         case_name = config["analysis"]["case_id"]
     threads:
-        get_threads(cluster_config, "tiddit_tumor_normal")
+        get_threads(cluster_config, "tiddit_sv_tumor_normal")
     message:
         ("Calling structural variants using tiddit for {params.case_name}")
     shell:

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_only.rule
@@ -111,7 +111,7 @@ echo -e \"{params.tumor}\\tTUMOR\" > {output.namemap};
 rm -rf {params.tmpdir};
         """
 
-rule tiddit_tumor_only:
+rule tiddit_sv_tumor_only:
     input:
         fa = config["reference"]["reference_genome"],
         bamT = bam_dir + tumor_bam,
@@ -120,7 +120,7 @@ rule tiddit_tumor_only:
         cov_tumor_tiddit = vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".tumor.tiddit_cov.bed",
         namemap= vcf_dir + "SV.somatic." + config["analysis"]["case_id"] + ".tiddit.sample_name_map",
     benchmark:
-        benchmark_dir + 'tiddit_tumor_only_' + config["analysis"]["case_id"] + ".tsv"
+        benchmark_dir + 'tiddit_sv_tumor_only_' + config["analysis"]["case_id"] + ".tsv"
     singularity:
         Path(singularity_image, config["bioinfo_tools"].get("tiddit") + ".sif").as_posix()
     params:
@@ -129,7 +129,7 @@ rule tiddit_tumor_only:
         tumor = "TUMOR",
         case_name = config["analysis"]["case_id"]
     threads:
-        get_threads(cluster_config, "tiddit_tumor_only")
+        get_threads(cluster_config, "tiddit_sv_tumor_only")
     message:
         ("Calling structural variants using tiddit for {params.case_name}")
     shell:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 Fixed:
 ^^^^^^
 
-* TIDDIT delivery rule names (undo changes made in Balsamic 10.0.1) https://github.com/Clinical-Genomics/BALSAMIC/pull/977
+* TIDDIT delivery rule names (undo rule name changes made in Balsamic 10.0.1) https://github.com/Clinical-Genomics/BALSAMIC/pull/977
 
 [10.0.1]
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 Fixed:
 ^^^^^^
 
-* TIDDIT delivery rule names (undo changes made in Balsamic 10.0.1)
+* TIDDIT delivery rule names (undo changes made in Balsamic 10.0.1) https://github.com/Clinical-Genomics/BALSAMIC/pull/977
 
 [10.0.1]
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+[10.0.2]
+---------
+
+Fixed:
+^^^^^^
+
+* TIDDIT delivery rule names (undo changes made in Balsamic 10.0.1)
+
 [10.0.1]
 ---------
 


### PR DESCRIPTION
### This PR:

When fixing the TIDDIT shell calls, the rule names were also changed https://github.com/Clinical-Genomics/BALSAMIC/pull/973. However, the delivery rules were not updated accordingly.

This PR undoes those name changes in order to re-include the TIDDIT files in the delivered `.hk` file.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
