### PR TITLE
Feat: adding missing features for PON version and CNVkit_TN PON usgae

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/cnvkit_paired.rule
@@ -1,5 +1,12 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
+#
+
+def get_pon_cnn(config):
+    if "pon_cnn" in config["panel"]:
+        return os.path.abspath(config["panel"]["pon_cnn"])
+    else:
+        return None
 
 rule cnvkit_paired:
     input:
@@ -34,7 +41,8 @@ rule cnvkit_paired:
         case_name = config["analysis"]["case_id"],
         gender = config["analysis"]["gender"],
         sample_id = "TUMOR",
-        genome = config["reference"]["genome_version"]
+        genome = config["reference"]["genome_version"],
+        pon = " " if get_pon_cnn(config) is None else get_pon_cnn(config)
     message:
         "Calling CNVs using CNVkit and calculating tumor purity/ploidy using PureCN for {params.case_name}"
     shell:
@@ -86,11 +94,24 @@ cnvkit.py reference \
 --output {params.cnv_dir}/normalReference.cnn;
 
 # Combine the uncorrected target and antitarget coverage tables (.cnn) and
-# correct for biases in regional coverage and GC content, according to the given normal reference
+# correct for biases in regional coverage and GC content, according to the given normal or PON reference
+
+if [[ ! -f "{params.pon}" ]]; then
+cnvkit.py reference \
+{params.cnv_dir}/normal.targetcoverage.cnn \
+{params.cnv_dir}/normal.antitargetcoverage.cnn \
+--fasta {input.fasta} \
+--output {params.cnv_dir}/normalReference.cnn;
+
 cnvkit.py fix {params.cnv_dir}/tumor.targetcoverage.cnn \
 {params.cnv_dir}/tumor.antitargetcoverage.cnn \
 {params.cnv_dir}/normalReference.cnn \
 --output {output.cnr};
+else
+echo "PON reference exists- Using it for coverage correction"
+cnvkit.py fix {params.cnv_dir}/tumor.targetcoverage.cnn {params.cnv_dir}/tumor.antitargetcoverage.cnn {params.pon} --output {output.cnr};
+fi
+
 
 # Infer copy number segments from the given coverage table
 # segmentattion methods (-m): cbs: reccommended for mid-size target panels and exomes

--- a/BALSAMIC/workflows/PON.smk
+++ b/BALSAMIC/workflows/PON.smk
@@ -31,6 +31,7 @@ access_5kb_hg19 = config["reference"]["access_regions"]
 target_bed = config["panel"]["capture_kit"]
 singularity_image = config["singularity"]["image"]
 benchmark_dir = config["analysis"]["benchmark"]
+version = "v1"
 
 tmp_dir = os.path.join(get_result_dir(config), "tmp", "" )
 Path.mkdir(Path(tmp_dir), exist_ok=True)
@@ -42,8 +43,8 @@ panel_name = os.path.split(target_bed)[1].replace('.bed','')
 
 coverage_references = expand(cnv_dir + "{sample}.{cov}coverage.cnn", sample=samples, cov=['target','antitarget'])
 baited_beds = expand(cnv_dir + "{cov}.bed", cov=['target','antitarget'])
-pon_reference = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.cnn")
-pon_finish = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference.done")
+pon_reference = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference_" + version + ".cnn")
+pon_finish = expand(cnv_dir + panel_name + "_" + config["analysis"]["case_id"] + "_PON_reference_"+ version +".done")
 
 config["rules"] = ["snakemake_rules/quality_control/fastp.rule", 
                    "snakemake_rules/align/bwa_mem.rule"]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+[X.X.X]
+-------
+
+Added:
+^^^^^^
+
+* Use of PON reference, if exists for CNVkit tumor-normal analysis
+
+Changed:
+^^^^^^^^
+
+* Added version number to the PON reference filename (`.cnn`) 
+
 [10.0.2]
 ---------
 


### PR DESCRIPTION
### This PR:

Added:

- Version number for the PON reference filenames (v*), where in future the production decided to include more normal samples and generate a new PON reference file, inclusions of version numbers in the filenames will add traceability.

- For panel TN cases, the condition to use the existence of PON reference was not included in CNVkit tumor-normal rule. Previously it was only implemented for Tumor-only cases. 



### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
