### PR TITLE
fix: Increase sambamba run time

### DIFF
--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -85,7 +85,7 @@
 		"n": 4
 	},
 	"sambamba_exon_depth": {
-		"time": "02:30:00",
+		"time": "04:00:00",
 		"n": 8
 	},
 	"sambamba_panel_depth": {

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -67,5 +67,6 @@ sambamba depth region \
 --filter {params.filter_string} \
 --cov-threshold {params.cov_1} --cov-threshold {params.cov_2} \
 --cov-threshold {params.cov_3} --cov-threshold {params.cov_4} \
---cov-threshold {params.cov_5} {input.bam} > {output};
+--cov-threshold {params.cov_5} {input.bam} > {output} \
+--nthreads {threads};
         """

--- a/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/sambamba_depth.rule
@@ -32,6 +32,7 @@ sambamba depth region \
 --regions {input.bed} \
 --min-base-quality={params.base_qual} \
 --filter {params.filter_string} \
+--nthreads {threads} \
 `echo $covStr` {input.bam} > {output}; 
         """
 
@@ -67,6 +68,6 @@ sambamba depth region \
 --filter {params.filter_string} \
 --cov-threshold {params.cov_1} --cov-threshold {params.cov_2} \
 --cov-threshold {params.cov_3} --cov-threshold {params.cov_4} \
---cov-threshold {params.cov_5} {input.bam} > {output} \
---nthreads {threads};
+--cov-threshold {params.cov_5} \
+--nthreads {threads} {input.bam} > {output};
         """

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
-[10.0.3]
-
+[10.0.4]
+---------
 Fixed:
+^^^^^^
+
+* Increase sambamba_exon_depth rule run time https://github.com/Clinical-Genomics/BALSAMIC/pull/1001
+
+[10.0.3]
+---------
+Fixed:
+^^^^^^
 
 * Input VCF files for cnvkit rules, cnvkit command and container https://github.com/Clinical-Genomics/BALSAMIC/pull/995
 


### PR DESCRIPTION
### This PR:

Recent cases failed on run time for the sambamba_exon_depth rule:

`slurmstepd: error: *** JOB 3715107 ON compute-0-11 CANCELLED AT 2022-09-22T22:01:04 DUE TO TIME LIMIT ***`


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
