### PR TITLE
fix: invalid bam flag using picardtools

### DIFF
--- a/BALSAMIC/constants/workflow_params.py
+++ b/BALSAMIC/constants/workflow_params.py
@@ -113,6 +113,14 @@ WORKFLOW_PARAMS = {
         "pcr_model": "NONE",
         "align_header": "'@RG\\tID:{sample}\\tSM:{sample}\\tPL:ILLUMINAi'",
         "min_mapq": "20",
+        "picard_fixmate": " ".join(
+            [
+                "-ADD_MATE_CIGAR true",
+                "-MAX_RECORDS_IN_RAM 10000000",
+                "-CREATE_INDEX true",
+                "-CREATE_MD5_FILE true",
+            ]
+        ),
         "picard_RG_normal": " ".join(
             [
                 "-RGPU ILLUMINAi",
@@ -120,6 +128,9 @@ WORKFLOW_PARAMS = {
                 "-RGSM NORMAL",
                 "-RGPL ILLUMINAi",
                 "-RGLB ILLUMINAi",
+                "-MAX_RECORDS_IN_RAM 10000000",
+                "-CREATE_INDEX true",
+                "-CREATE_MD5_FILE true",
             ]
         ),
         "picard_RG_tumor": " ".join(
@@ -129,6 +140,9 @@ WORKFLOW_PARAMS = {
                 "-RGSM TUMOR",
                 "-RGPL ILLUMINAi",
                 "-RGLB ILLUMINAi",
+                "-MAX_RECORDS_IN_RAM 10000000",
+                "-CREATE_INDEX true",
+                "-CREATE_MD5_FILE true",
             ]
         ),
     },

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_normal.rule
@@ -13,7 +13,7 @@ rule mergeBam_normal:
     fasta = config["reference"]["reference_genome"],
     bam = bam_dir + normal_bam 
   output:
-    bam = bam_dir + "normal.merged.bam", 
+    bam = bam_dir + "normal.merged.bam",
     cram = bam_dir + "normal.merged.cram",
   benchmark:
     Path(benchmark_dir,'mergeBam_normal_' + "{mysample}.tsv".format(mysample=normal_sample)).as_posix()
@@ -31,23 +31,23 @@ rule mergeBam_normal:
     "Replacing bam header using Picardtools for {params.sample}"
   shell:
     """
-picard FixMateInformation {params.picard_fixmateinfo} |\
--TMP_DIR {params.tmpdir} |\
--INPUT {input.bam} |\
+picard FixMateInformation {params.picard_fixmateinfo} \
+-TMP_DIR {params.tmpdir} \
+-INPUT {input.bam} \
 -OUTPUT {params.tmpdir}/normal.fixed.bam;
 
-samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/normal.fixed.bam |\
+samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/normal.fixed.bam \
 -o {params.tmpdir}/normal.fixed.um.bam;
 
 samtools index {params.tmpdir}/normal.fixed.um.bam;
 
-samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/normal.fixed.bam |\
+samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/normal.fixed.bam \
 -o {params.tmpdir}/normal.fixed.m.bam;
 
 samtools index {params.tmpdir}/normal.fixed.m.bam;
 
-picard AddOrReplaceReadGroups {params.picard_rg} |\
--INPUT {params.tmpdir}/normal.fixed.m.bam |\
+picard AddOrReplaceReadGroups {params.picard_rg} \
+-INPUT {params.tmpdir}/normal.fixed.m.bam \
 -OUTPUT {output.bam}; 
 
 samtools index {output.bam}; 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_normal.rule
@@ -21,7 +21,8 @@ rule mergeBam_normal:
     Path(singularity_image, config["bioinfo_tools"].get("picard") + ".sif").as_posix()
   params:
     housekeeper_id = {"id": normal_sample, "tags": "normal"},
-    picard = params.common.picard_RG_normal,
+    picard_fixmateinfo = params.common.picard_fixmate,
+    picard_rg = params.common.picard_RG_normal,
     sample = normal_sample,
     tmpdir= tempfile.mkdtemp(prefix=tmp_dir),
   threads:
@@ -30,17 +31,24 @@ rule mergeBam_normal:
     "Replacing bam header using Picardtools for {params.sample}"
   shell:
     """
-samtools collate --threads {threads} -Ou {input.bam} {params.tmpdir}/{params.sample} |\
-samtools fixmate --threads {threads} - - |\
-samtools sort --threads {threads} -O BAM -o {params.tmpdir}/normal.fixed.bam -;
+picard FixMateInformation {params.picard_fixmateinfo} |\
+-TMP_DIR {params.tmpdir} |\
+-INPUT {input.bam} |\
+-OUTPUT {params.tmpdir}/normal.fixed.bam;
 
-samtools index {params.tmpdir}/normal.fixed.bam;
+samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/normal.fixed.bam |\
+-o {params.tmpdir}/normal.fixed.um.bam;
 
-samtools view --threads {threads} -b -F 4 {params.tmpdir}/normal.fixed.bam > {params.tmpdir}/normal.fixed.m.bam;
+samtools index {params.tmpdir}/normal.fixed.um.bam;
+
+samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/normal.fixed.bam |\
+-o {params.tmpdir}/normal.fixed.m.bam;
 
 samtools index {params.tmpdir}/normal.fixed.m.bam;
 
-picard AddOrReplaceReadGroups {params.picard} -INPUT {params.tmpdir}/normal.fixed.m.bam -OUTPUT {output.bam}; 
+picard AddOrReplaceReadGroups {params.picard_rg} |\
+-INPUT {params.tmpdir}/normal.fixed.m.bam |\
+-OUTPUT {output.bam}; 
 
 samtools index {output.bam}; 
 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -31,23 +31,23 @@ rule mergeBam_tumor:
     "Replacing bam header using Picardtools for {params.sample}"
   shell:
     """
-picard FixMateInformation {params.picard_fixmateinfo} |\
--TMP_DIR {params.tmpdir} |\
--INPUT {input.bam} |\
+picard FixMateInformation {params.picard_fixmateinfo} \
+-TMP_DIR {params.tmpdir} \
+-INPUT {input.bam} \
 -OUTPUT {params.tmpdir}/tumor.fixed.bam;
 
-samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/tumor.fixed.bam |\
+samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/tumor.fixed.bam \
 -o {params.tmpdir}/tumor.fixed.um.bam ;
 
 samtools index {params.tmpdir}/tumor.fixed.um.bam;
 
-samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/tumor.fixed.bam |\
+samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/tumor.fixed.bam \
 -o {params.tmpdir}/tumor.fixed.m.bam;
 
 samtools index {params.tmpdir}/tumor.fixed.m.bam;
 
-picard AddOrReplaceReadGroups {params.picard_rg} |\
--INPUT {params.tmpdir}/tumor.fixed.m.bam |\
+picard AddOrReplaceReadGroups {params.picard_rg} \
+-INPUT {params.tmpdir}/tumor.fixed.m.bam \
 -OUTPUT {output.bam}; 
 
 samtools index {output.bam}; 

--- a/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/mergetype_tumor.rule
@@ -21,7 +21,8 @@ rule mergeBam_tumor:
     Path(singularity_image, config[ "bioinfo_tools" ].get("picard") + ".sif").as_posix()
   params:
     housekeeper_id = {"id": tumor_sample, "tags": "tumor"},
-    picard = params.common.picard_RG_tumor,
+    picard_fixmateinfo = params.common.picard_fixmate,
+    picard_rg = params.common.picard_RG_tumor,
     sample = tumor_sample,
     tmpdir= tempfile.mkdtemp(prefix=tmp_dir),
   threads:
@@ -30,17 +31,24 @@ rule mergeBam_tumor:
     "Replacing bam header using Picardtools for {params.sample}"
   shell:
     """
-samtools collate --threads {threads} -Ou {input.bam} {params.tmpdir}/{params.sample} |\
-samtools fixmate --threads {threads} - - |\
-samtools sort --threads {threads} -O BAM -o {params.tmpdir}/tumor.fixed.bam -;
+picard FixMateInformation {params.picard_fixmateinfo} |\
+-TMP_DIR {params.tmpdir} |\
+-INPUT {input.bam} |\
+-OUTPUT {params.tmpdir}/tumor.fixed.bam;
 
-samtools index {params.tmpdir}/tumor.fixed.bam;
+samtools view --threads {threads} -O BAM -F 4 {params.tmpdir}/tumor.fixed.bam |\
+-o {params.tmpdir}/tumor.fixed.um.bam ;
 
-samtools view --threads {threads} -b -F 4 {params.tmpdir}/tumor.fixed.bam > {params.tmpdir}/tumor.fixed.m.bam ;
+samtools index {params.tmpdir}/tumor.fixed.um.bam;
+
+samtools view --threads {threads} -O BAM -f 4 {params.tmpdir}/tumor.fixed.bam |\
+-o {params.tmpdir}/tumor.fixed.m.bam;
 
 samtools index {params.tmpdir}/tumor.fixed.m.bam;
 
-picard AddOrReplaceReadGroups {params.picard} -INPUT {params.tmpdir}/tumor.fixed.m.bam -OUTPUT {output.bam}; 
+picard AddOrReplaceReadGroups {params.picard_rg} |\
+-INPUT {params.tmpdir}/tumor.fixed.m.bam |\
+-OUTPUT {output.bam}; 
 
 samtools index {output.bam}; 
 

--- a/BALSAMIC/utils/models.py
+++ b/BALSAMIC/utils/models.py
@@ -719,6 +719,7 @@ class ParamsCommon(BaseModel):
         pcr_model: str (required). PCR indel model used to weed out false positive indels. Eg: none- PCR free samples.
         align_header: str (required); header line appended to the aligned BAM output
         min_mapq: int (required); minimum mapping quality score. Eg: 20- probability of mapping random read at 99% accuracy
+        picard_fixmate: str (required), fix read mate information in bam file
         picard_RG_normal: str (required); replace readgroups in normal bam file
         picard_RG_tumor: str (required); replace readgroups in tumor bam file
     """
@@ -726,6 +727,7 @@ class ParamsCommon(BaseModel):
     align_header: str
     pcr_model: str
     min_mapq: int
+    picard_fixmate: str
     picard_RG_normal: str
     picard_RG_tumor: str
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Fixed:
 * samtools command in merge bam and names in toml for vcfanno https://github.com/Clinical-Genomics/BALSAMIC/pull/1020
 * If statement in `vep_somatic_clinical_snv` rule https://github.com/Clinical-Genomics/BALSAMIC/pull/1022
 * Invalid flag second of pair validation error https://github.com/Clinical-Genomics/BALSAMIC/pull/1025
+* Invalid flag second of pair validation error using picardtools https://github.com/Clinical-Genomics/BALSAMIC/pull/102
 
 Removed:
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Fixed:
 * samtools command in merge bam and names in toml for vcfanno https://github.com/Clinical-Genomics/BALSAMIC/pull/1020
 * If statement in `vep_somatic_clinical_snv` rule https://github.com/Clinical-Genomics/BALSAMIC/pull/1022
 * Invalid flag second of pair validation error https://github.com/Clinical-Genomics/BALSAMIC/pull/1025
-* Invalid flag second of pair validation error using picardtools https://github.com/Clinical-Genomics/BALSAMIC/pull/102
+* Invalid flag second of pair validation error using picardtools https://github.com/Clinical-Genomics/BALSAMIC/pull/1027
 
 Removed:
 ^^^^^^^


### PR DESCRIPTION
### This PR:
The bam files generated multiple errors showing an invalid bam flag for numerous reads. Samtools could fix a few of them, but not all. Picard tools fixmateinformation command performs better than samtools and fixes the invalid bam flags.
The origin of these errors is concatenated fastq file. The current PR fixes the issue, but it would be better to use each fastq as input and merge bam files instead.

Fixed: invalid bam flag using `Picard tools`.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
