### PR TITLE
fix: SV quality filter

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_quality_filter.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_quality_filter.rule
@@ -15,7 +15,7 @@ rule bcftools_quality_filter_svdb:
     "Filtering merged research structural and copy number variants using bcftools for {params.case_name}"
   shell:
     """
-bcftools view --threads {threads} -f .,PASS -o {output.vcf_pass_svdb_research} -O z {input.vcf_svdb};
+bcftools view --threads {threads} -f .,PASS,MaxDepth -o {output.vcf_pass_svdb_research} -O z {input.vcf_svdb};
 
 tabix -p vcf -f {output.vcf_pass_svdb_research};
     """

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 [X.X.X]
 
 Fixed:
-* MacDepth in quality filter for SV https://github.com/Clinical-Genomics/BALSAMIC/pull/10
+* MacDepth in quality filter for SV https://github.com/Clinical-Genomics/BALSAMIC/pull/1051
 
 [11.0.1]
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-[X.X.X]
+[11.0.2]
 
 Fixed:
 * MacDepth in quality filter for SV https://github.com/Clinical-Genomics/BALSAMIC/pull/1051

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+[X.X.X]
+
+Fixed:
+* MacDepth in quality filter for SV https://github.com/Clinical-Genomics/BALSAMIC/pull/10
+
 [11.0.1]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 [11.0.2]
 
 Fixed:
+^^^^^^
+
 * MacDepth in quality filter for SV https://github.com/Clinical-Genomics/BALSAMIC/pull/1051
 
 [11.0.1]


### PR DESCRIPTION
### This PR:

Fixed: `bfcftools` filter command in SV quality filter to not filter out variants that are filtered out as `MaxDepth`.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
