### PR TITLE
perf: Parallelize download reference

### DIFF
--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -235,7 +235,7 @@ rule download_reference:
     output:
         os.path.join("{ref_subdir}","{ref_file}"),
     run:
-        download_reference_file({output})
+        download_reference_file(output[0])
 
 
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -232,7 +232,6 @@ wildcard_constraints:
 rule download_reference:
     output:
         os.path.join("{ref_subdir}","{downloaded_file}"),
-    retries: 1
     run:
         download_reference_file({output})
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -224,14 +224,16 @@ def download_reference_file(output_file):
     ref.write_md5
 
 ref_subdirs = set([ref.output_path for ref in download_content])
+ref_files = set([ref.output_file for ref in download_content])
 
 wildcard_constraints:
     ref_subdir="|".join(ref_subdirs),
+    ref_file = "|".join(ref_files),
 
 
 rule download_reference:
     output:
-        os.path.join("{ref_subdir}","{downloaded_file}"),
+        os.path.join("{ref_subdir}","{ref_file}"),
     run:
         download_reference_file({output})
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -233,7 +233,7 @@ wildcard_constraints:
 
 rule download_reference:
     output:
-        os.path.join("{ref_subdir}","{ref_file}"),
+        Path("{ref_subdir}","{ref_file}").as_posix(),
     run:
         download_reference_file(output[0])
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -194,36 +194,50 @@ download_content = [reference_genome_url, dbsnp_url, hc_vcf_1kg_url,
                     delly_mappability_findex_url, ascat_gccorrection_url, ascat_chryloci_url, clinvar_url,
                     somalier_sites_url]
 
+download_dict = dict([(ref.get_output_file, ref) for ref in download_content])
+
+def download_reference_file(output_file):
+    import requests
+
+    ref = download_dict[output_file]
+    log_file = output_file + ".log"
+
+    if ref.url.scheme == "gs":
+        cmd = "export TMPDIR=/tmp; gsutil cp -L {} {} -".format(log_file,ref.url)
+    else:
+        cmd = "wget -a {} -O - {}".format(log_file,ref.url)
+
+    if ref.secret:
+        try:
+            response = requests.get(ref.url,headers={'Authorization': 'Basic %s' % ref.secret})
+            download_url = response.json()["url"]
+        except:
+            LOG.error("Unable to download {}".format(ref.url))
+            raise
+        cmd = "curl -o - '{}'".format(download_url)
+
+    if ref.gzip:
+        cmd += " | gunzip "
+
+    cmd += " > {}".format(output_file)
+    shell(cmd)
+    ref.write_md5
+
+ref_subdirs = set([ref.output_path for ref in download_content])
+
+wildcard_constraints:
+    ref_subdir="|".join(ref_subdirs),
+
+
 rule download_reference:
     output:
-        expand("{output}", output=[ref.get_output_file for ref in download_content])
+        os.path.join("{ref_subdir}","{downloaded_file}"),
+    retries: 1
     run:
-        import requests
+        download_reference_file({output})
 
-        for ref in download_content:
-            output_file = ref.get_output_file
-            log_file = output_file + ".log"
 
-            if ref.url.scheme == "gs":
-                cmd = "export TMPDIR=/tmp; gsutil cp -L {} {} -".format(log_file, ref.url)
-            else:
-                cmd = "wget -a {} -O - {}".format(log_file, ref.url)
 
-            if ref.secret:
-                try:
-                    response = requests.get(ref.url, headers={'Authorization': 'Basic %s' % ref.secret })
-                    download_url = response.json()["url"]
-                except:
-                    LOG.error("Unable to download {}".format(ref.url))
-                    raise
-                cmd = "curl -o - '{}'".format(download_url)
-            
-            if ref.gzip:
-                cmd += " | gunzip "
-
-            cmd += " > {}".format(output_file)
-            shell(cmd)
-            ref.write_md5
 
 ##########################################################
 # Preprocess refseq file by fetching relevant columns and 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Added:
 ^^^^^^
 * Added somalier integration and relatedness check: https://github.com/Clinical-Genomics/BALSAMIC/pull/1017
 
+Changed:
+^^^^^^^^
+* Parallelize download of reference files https://github.com/Clinical-Genomics/BALSAMIC/pull/1065
+
+
 Fixed:
 ^^^^^^
 * test_write_json failing locally https://github.com/Clinical-Genomics/BALSAMIC/pull/1063


### PR DESCRIPTION
### This PR:

Fixes https://github.com/Clinical-Genomics/BALSAMIC/issues/1064 

Changed: parallelize download of reference files

### How to tests:

- [x] Dry-run of `balsamic init --outdir $path2balsamic_cache --cosmic-key "${COSMIC_KEY}" --genome-version hg19 --run-mode local --snakemake-opt "--cores 36" --container-version develop`
- [x] Make sure that `download_reference` is set for multiple executions (count > 1)
- [x] Run of `balsamic init --outdir $path2balsamic_cache --cosmic-key "${COSMIC_KEY}" --genome-version hg19 --run-mode local --snakemake-opt "--cores 2 --until download_reference" --container-version develop -r`

### Review and tests: 
- [x] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
