### PR TITLE
perf: Parallelize container download

### DIFF
--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -184,7 +184,7 @@ def download_container_file(output_file):
     shell(cmd)
 
 rule download_container:
-    output: Path("singularity_image_path", "{container_image}" + ".sif").as_posix(),
+    output: Path(singularity_image_path, "{container_image}" + ".sif").as_posix(),
     run:
       download_container_file(output[0])
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -177,7 +177,7 @@ rule all:
 wildcard_constraints:
     container_image = "|".join(list(config["singularity"]["containers"])),
 
-def download_container_file(output_file):
+def download_container_file(output_file: str):
     image_name = Path(output_file).stem
     docker_path = config["singularity"]["containers"][image_name]
     cmd = "singularity pull {}/{}.sif {}".format(config["singularity"]["image_path"],image_name,docker_path)
@@ -186,7 +186,7 @@ def download_container_file(output_file):
 rule download_container:
     output: Path(singularity_image_path, "{container_image}" + ".sif").as_posix(),
     run:
-      download_container_file(output[0])
+      download_container_file(output_file=output[0])
 
 ##########################################################
 # Download the reference genome, variant db 
@@ -202,7 +202,7 @@ download_content = [reference_genome_url, dbsnp_url, hc_vcf_1kg_url,
 
 download_dict = dict([(ref.get_output_file, ref) for ref in download_content])
 
-def download_reference_file(output_file):
+def download_reference_file(output_file: str):
     import requests
 
     ref = download_dict[output_file]
@@ -241,7 +241,7 @@ rule download_reference:
     output:
         Path("{ref_subdir}","{ref_file}").as_posix(),
     run:
-        download_reference_file(output[0])
+        download_reference_file(output_file=output[0])
 
 
 

--- a/BALSAMIC/workflows/reference.smk
+++ b/BALSAMIC/workflows/reference.smk
@@ -174,13 +174,19 @@ rule all:
 ###########################################################
 # Download all singularity container images from dockerhub
 ###########################################################
+wildcard_constraints:
+    container_image = "|".join(list(config["singularity"]["containers"])),
+
+def download_container_file(output_file):
+    image_name = Path(output_file).stem
+    docker_path = config["singularity"]["containers"][image_name]
+    cmd = "singularity pull {}/{}.sif {}".format(config["singularity"]["image_path"],image_name,docker_path)
+    shell(cmd)
 
 rule download_container:
-    output: singularity_images
+    output: Path("singularity_image_path", "{container_image}" + ".sif").as_posix(),
     run:
-      for image_name, docker_path in config["singularity"]["containers"].items():
-          cmd = "singularity pull {}/{}.sif {}".format(config["singularity"]["image_path"], image_name, docker_path)
-	  shell(cmd)
+      download_container_file(output[0])
 
 ##########################################################
 # Download the reference genome, variant db 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Added:
 ^^^^^^
 * Added somalier integration and relatedness check: https://github.com/Clinical-Genomics/BALSAMIC/pull/1017
 
+Changed:
+^^^^^^^^
+* Parallelize download of container images https://github.com/Clinical-Genomics/BALSAMIC/pull/1068
+
 Fixed:
 ^^^^^^
 * test_write_json failing locally https://github.com/Clinical-Genomics/BALSAMIC/pull/1063


### PR DESCRIPTION
### This PR:

Fixes https://github.com/Clinical-Genomics/BALSAMIC/issues/1066 

Changed: parallelize download of container images

### How to tests:

- [x] Dry-run of `balsamic init --outdir $path2balsamic_cache --cosmic-key "${COSMIC_KEY}" --genome-version hg19 --run-mode local --snakemake-opt "--cores 2 -R download_container --until download_container" --container-version develop`
- [x] Make sure that `download_container` is set for multiple executions (count > 1)
- [x] Run of `balsamic init --outdir $path2balsamic_cache --cosmic-key "${COSMIC_KEY}" --genome-version hg19 --run-mode local --snakemake-opt "--cores 2 --until download_container" --container-version develop -r`

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
