### PR TITLE
fix: change somalier container user to defaultuser

### DIFF
--- a/BALSAMIC/containers/somalier/Dockerfile
+++ b/BALSAMIC/containers/somalier/Dockerfile
@@ -10,10 +10,6 @@ ARG nim_version=1.6.6
 
 ENV CFLAGS="-fPIC -O3"
 
-RUN adduser -D defaultuser
-
-USER defaultuser
-
 RUN apk add --no-cache wget git autoconf tar xz xz-dev bzip2-dev curl curl-dev bash libzip-dev cmake openblas-dev build-base
 
 RUN mkdir -p /usr/local/include && \
@@ -56,3 +52,8 @@ RUN cd /somalier &&  \
     rm -rf /somalier && somalier --help
 
 ENV somalier_ancestry_labels /ancestry_labels-1kg.tsv
+
+RUN adduser -D defaultuser
+
+USER defaultuser
+

--- a/BALSAMIC/containers/somalier/Dockerfile
+++ b/BALSAMIC/containers/somalier/Dockerfile
@@ -10,6 +10,10 @@ ARG nim_version=1.6.6
 
 ENV CFLAGS="-fPIC -O3"
 
+RUN adduser -D defaultuser
+
+USER defaultuser
+
 RUN apk add --no-cache wget git autoconf tar xz xz-dev bzip2-dev curl curl-dev bash libzip-dev cmake openblas-dev build-base
 
 RUN mkdir -p /usr/local/include && \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Fixed:
 * `test_write_json` failing locally https://github.com/Clinical-Genomics/BALSAMIC/pull/1063
 * Container build and push via github actions by setting buildx `provenance` flag to false https://github.com/Clinical-Genomics/BALSAMIC/pull/1071
 * Added buildx to the submodule workflow https://github.com/Clinical-Genomics/BALSAMIC/pull/1072
-
+* Change user in somalier container to defaultuser https://github.com/Clinical-Genomics/BALSAMIC/pull/1080
 
 [11.0.2]
 


### PR DESCRIPTION
### This PR:

Addresses security hotspot related to using alpine docker with the default root user in somalier. It changes it to `defaultuser` instead

Fixed: somalier container user to non-root user


### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
