### PR TITLE
refactor: Update cryptography version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,17 @@
+[X.X.X]
+--------
+
+Fixed:
+^^^^^^
+* Update cryptography version (39.0.1) due to security alert https://github.com/Clinical-Genomics/BALSAMIC/pull/1087
+
 [11.1.0]
 --------
 
 Added:
 ^^^^^^
 * Added somalier integration and relatedness check: https://github.com/Clinical-Genomics/BALSAMIC/pull/1017
-* Cluster resources for CNVPytor tumor only https://github.com/Clinical-Genomics/BALSAMIC/pull/1083 
+* Cluster resources for CNVPytor tumor only https://github.com/Clinical-Genomics/BALSAMIC/pull/1083
 
 Changed:
 ^^^^^^^^
@@ -14,7 +21,7 @@ Changed:
 Fixed:
 ^^^^^^
 * triallelic_site in quality filter for SNV https://github.com/Clinical-Genomics/BALSAMIC/pull/1052
-* Compression of SNV, research and clinical, VCF files https://github.com/Clinical-Genomics/BALSAMIC/pull/1060 
+* Compression of SNV, research and clinical, VCF files https://github.com/Clinical-Genomics/BALSAMIC/pull/1060
 * `test_write_json` failing locally https://github.com/Clinical-Genomics/BALSAMIC/pull/1063
 * Container build and push via github actions by setting buildx `provenance` flag to false https://github.com/Clinical-Genomics/BALSAMIC/pull/1071
 * Added buildx to the submodule workflow https://github.com/Clinical-Genomics/BALSAMIC/pull/1072

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requirements = [
     "h5py>=3.6.0",
     "PyPDF2>=1.26.0",
     "markdown==3.3.3",
-    "cryptography==3.2.1",
+    "cryptography==39.0.1",
     "tabulate==0.8.10",
     "toml==0.10.2",
 ]


### PR DESCRIPTION
### This PR:

Addresses security alerts linked to cryptography version:
https://github.com/Clinical-Genomics/BALSAMIC/security/dependabot/2

It will also fix the critical alert dismissed in the past:
https://github.com/Clinical-Genomics/BALSAMIC/security/dependabot/1

### Review and tests: 
- [x] Tests pass
<img width="700" alt="Screenshot 2023-02-08 at 10 27 36" src="https://user-images.githubusercontent.com/26309194/217489593-cb492d68-21d4-449f-a761-e95d508c7d98.png">

- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
