### PR TITLE
fix: VEP filters away variants too long to annotate

### DIFF
--- a/BALSAMIC/constants/workflow_params.py
+++ b/BALSAMIC/constants/workflow_params.py
@@ -153,7 +153,7 @@ WORKFLOW_PARAMS = {
         "column_info": "-c 1 -S 2 -E 3 -g 4",
     },
     "vep": {
-        "vep_filters": "--compress_output bgzip --vcf --everything --hgvsg --allow_non_variant --dont_skip --buffer_size 30000 --format vcf --offline --variant_class --merged --cache --verbose --force_overwrite"
+        "vep_filters": "--compress_output bgzip --vcf --everything --hgvsg --allow_non_variant --dont_skip --buffer_size 30000 --max_sv_size 248956422 --format vcf --offline --variant_class --merged --cache --verbose --force_overwrite"
     },
     "umicommon": {
         "align_header": "'@RG\\tID:{sample}\\tSM:{sample}\\tLB:TargetPanel\\tPL:ILLUMINA'",

--- a/BALSAMIC/constants/workflow_params.py
+++ b/BALSAMIC/constants/workflow_params.py
@@ -153,7 +153,7 @@ WORKFLOW_PARAMS = {
         "column_info": "-c 1 -S 2 -E 3 -g 4",
     },
     "vep": {
-        "vep_filters": "--compress_output bgzip --vcf --everything --hgvsg --allow_non_variant --dont_skip --buffer_size 30000 --max_sv_size 248956422 --format vcf --offline --variant_class --merged --cache --verbose --force_overwrite"
+        "vep_filters": "--compress_output bgzip --vcf --everything --hgvsg --allow_non_variant --dont_skip --buffer_size 30000 --max_sv_size 249250621 --format vcf --offline --variant_class --merged --cache --verbose --force_overwrite"
     },
     "umicommon": {
         "align_header": "'@RG\\tID:{sample}\\tSM:{sample}\\tLB:TargetPanel\\tPL:ILLUMINA'",

--- a/BALSAMIC/containers/annotate/annotate.yaml
+++ b/BALSAMIC/containers/annotate/annotate.yaml
@@ -25,7 +25,7 @@ dependencies:
   - conda-package-streaming=0.7.0
   - cryptography=38.0.4
   - curl=7.82.0
-  - ensembl-vep=104.3
+  - ensembl-vep=109.3
   - expat=2.4.4
   - flit-core=3.6.0
   - fontconfig=2.13.1

--- a/BALSAMIC/containers/annotate/annotate.yaml
+++ b/BALSAMIC/containers/annotate/annotate.yaml
@@ -25,7 +25,7 @@ dependencies:
   - conda-package-streaming=0.7.0
   - cryptography=38.0.4
   - curl=7.82.0
-  - ensembl-vep=109.3
+  - ensembl-vep=104.3
   - expat=2.4.4
   - flit-core=3.6.0
   - fontconfig=2.13.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Added:
 Changed:
 ^^^^^^^^
 * Fixed all conda container dependencies https://github.com/Clinical-Genomics/BALSAMIC/pull/1096
+* Changed --max_sv_size in VEP params to the size of chr1 for hg19 https://github.com/Clinical-Genomics/BALSAMIC/pull/1124
 
 Fixed:
 ^^^^^^


### PR DESCRIPTION
### This PR:

Aims to solve the issue mentioned here: https://github.com/Clinical-Genomics/BALSAMIC/issues/1123 where SV calls longer than the default max_sv_size are filtered out rather than simple being left un-annotated in the output VCF (in versions  > 109 of VEP this was changed so that variants are not filtered out).

Another way to keep all variants, as well as to annotate them, is simply to increase the max_sv_size to the maximum possible size (the size of chromosome 1: 249250621 for hg19, which is larger than chromosome 1 in hg38 and should therefore be fine for both genome versions).

**Changed: for changes in existing functionality.**
- [x] Changed --max_sv_size in VEP params to the size of chr1 for hg19. 

### Tests to be done

- [x] Install branch on Hasta
- [x] Run analysis on WGS T / N case hardyweevil
- [x] Analysis succeeding without errors
- [x] Variants filtered out from VEP with warning "too long to annotate" are kept in downstream VCF and annotated in case hardyweevil:
    - [x] 24 variants from vep_germline_normal are annotated, not filtered out
    - [x] 42 variants from vep_germline_tumor are annotated, not filtered out
    - [x] 224 variants from vep_somatic_sv are annotated, not filtered out
    - [x] remaining VEP annotations are unchanged

### Review and tests: 
- [x] Tests pass
- [x] Code review
- [x] New code is executed and covered by tests, and test approve
