### PR TITLE
fix: increase_time_for_processes

### DIFF
--- a/BALSAMIC/config/cluster.json
+++ b/BALSAMIC/config/cluster.json
@@ -28,7 +28,7 @@
 		"n": 10
 	},
 	"picard_markduplicates": {
-		"time": "03:30:00",
+		"time": "06:00:00",
 		"n": 8
 	},
 	"bwa_mem": {
@@ -93,7 +93,7 @@
 		"n": 4
 	},
 	"sambamba_exon_depth": {
-		"time": "04:00:00",
+		"time": "06:00:00",
 		"n": 8
 	},
 	"sambamba_panel_depth": {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Added:
 Changed:
 ^^^^^^^^
 * Fixed all conda container dependencies https://github.com/Clinical-Genomics/BALSAMIC/pull/1096
+* Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours
 
 Fixed:
 ^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Added:
 Changed:
 ^^^^^^^^
 * Fixed all conda container dependencies https://github.com/Clinical-Genomics/BALSAMIC/pull/1096
-* Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours
+* Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours https://github.com/Clinical-Genomics/BALSAMIC/pull/1143
 
 Fixed:
 ^^^^^^


### PR DESCRIPTION
### This PR:

Increases time-limit for commonly timeout processes, picard_markduplicates and sambamba_exon_depth

Changed: 
* Increase time-limit for picard_markduplicates and sambamba_exon_depth to 6 hours

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
