### PR TITLE
fix: update read the docs for balsamic v12.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changed:
 * Changed --max_sv_size in VEP params to the size of chr1 for hg19 https://github.com/Clinical-Genomics/BALSAMIC/pull/1124
 * Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours https://github.com/Clinical-Genomics/BALSAMIC/pull/1143
 * Update cosmicdb to v97 https://github.com/Clinical-Genomics/BALSAMIC/pull/1147
-* Updated read the docs with the changes relevant to mention
+* Updated read the docs with the changes relevant to mention https://github.com/Clinical-Genomics/BALSAMIC/pull/1153
 
 Fixed:
 ^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changed:
 * Changed --max_sv_size in VEP params to the size of chr1 for hg19 https://github.com/Clinical-Genomics/BALSAMIC/pull/1124
 * Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours https://github.com/Clinical-Genomics/BALSAMIC/pull/1143
 * Update cosmicdb to v97 https://github.com/Clinical-Genomics/BALSAMIC/pull/1147
+* Updated read the docs with the changes relevant to mention
 
 Fixed:
 ^^^^^^

--- a/docs/balsamic_annotation.rst
+++ b/docs/balsamic_annotation.rst
@@ -94,6 +94,9 @@ The values for `ORIGIN` are described below:
 Where relevant, `BALSAMIC` uses `ensembl-vep` to annotate somatic and germline SNVs and somatic SVs/CNVs from `1000genomes (phase3)`, `ClinVar`, `ESP, HGMD-PUBLIC`, `dbSNP`, `gencode`, `gnomAD`, `polyphen`, `refseq`, and `sift` databases.
 The following annotations are added by `ensembl-vep`.
 
+VEP has a setting for the maximum size of a structural variant that it will annotate, currently this is set to the size of the size of chromosome 1 (in hg19) (`--max_sv_size 249250621`).
+
+
 .. list-table:: ensembl-vep
    :widths: 10 60
    :header-rows: 1

--- a/docs/balsamic_filters.rst
+++ b/docs/balsamic_filters.rst
@@ -15,7 +15,7 @@ In BALSAMIC, various bioinfo tools are integrated for reporting somatic and germ
      - Somatic/Germline
      - Variant type
    * - DNAscope
-     - WGS
+     - TGA, WGS
      - tumor-normal, tumor-only
      - germline
      - SNV, InDel
@@ -25,9 +25,9 @@ In BALSAMIC, various bioinfo tools are integrated for reporting somatic and germ
      - somatic
      - SNV, InDel
    * - TNScope_umi
-     - TGA, WGS
+     - TGA
      - tumor-normal, tumor-only
-     - somatic, germline
+     - somatic
      - SNV, InDel
    * - VarDict
      - TGA

--- a/docs/balsamic_filters.rst
+++ b/docs/balsamic_filters.rst
@@ -30,7 +30,7 @@ In BALSAMIC, various bioinfo tools are integrated for reporting somatic and germ
      - somatic, germline
      - SNV, InDel
    * - VarDict
-     - TGA, WGS
+     - TGA
      - tumor-normal, tumor-only
      - somatic
      - SNV, InDel

--- a/docs/balsamic_sv_cnv.rst
+++ b/docs/balsamic_sv_cnv.rst
@@ -47,9 +47,46 @@ Depending on the sequencing type, BALSAMIC is currently running the following st
 
 Further details about a specific caller can be found in the links for the repositories containing the documentation for SV and CNV callers along with the links for the articles are listed in `bioinfo softwares <https://balsamic.readthedocs.io/en/latest/bioinfo_softwares.html>`_.
 
-It mandatory to provide the gender of the sample from BALSAMIC version >= 10.0.0 For CNV analysis.
+It is mandatory to provide the gender of the sample from BALSAMIC version >= 10.0.0 For CNV analysis.
 
-The copy number variants, identified using ascatNgs and `dellycnv`, are converted to deletion and duplications before they are merged using `SVDB` with `--bnd_distance = 5000` (distance between end points for the variants from different callers) and  `--overlap = 0.80` (percentage for overlapping bases for the variants from different callers). `SVDB` prioritizes the merging of variants from SV and CNV callers to fetch position and genotype information,  in the following order:
+**Pre-merge Filtrations**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+The copy number variants, identified using ascatNgs and `dellycnv`, are converted to deletion and duplications before they are merged using `SVDB` with `--bnd_distance = 5000` (distance between end points for the variants from different callers) and  `--overlap = 0.80` (percentage for overlapping bases for the variants from different callers).
+
+Tumor and normal calls in `TIDDIT` are merged using `SVDB` with `--bnd_distance 500` and `--overlap = 0.80`.
+Using a custom made script "filter_SVs.py", soft-filters are added to the calls based on the presence of the variant in the normal, with the goal of retaining only somatic variants as PASS.
+
+
+.. list-table:: SV filters
+   :widths: 25 25 40
+   :header-rows: 1
+
+   * - Variant caller
+     - Filter added
+     - Filter expression
+   * - TIDDIT
+     - high_normal_af_fraction
+     - (AF_N_MAX / AF_T_MAX) > 0.25
+   * - TIDDIT
+     - max_normal_allele_frequency
+     - AF_N_MAX > 0.25
+   * - TIDDIT
+     - normal_variant
+     - AF_T_MAX == 0 and ctg_t == False
+   * - TIDDIT
+     - in_normal
+     - ctg_n == True and AF_N_MAX == 0 and AF_T_MAX <= 0.25
+
+
+Further information regarding the TIDDIT tumor normal filtration: As translocation variants are represented by 2 BNDs in the VCF which allows for mixed assignment of soft-filters, a requirement for assigning soft-filters to translocations is that neither BND is PASS.
+
+
+**Post-merge Filtrations**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`SVDB` prioritizes the merging of variants from SV and CNV callers to fetch position and genotype information,  in the following order:
 
 .. list-table:: SVDB merge caller priority order
    :widths: 25 25 25 25


### PR DESCRIPTION
### This PR:

Updates read the docs for release 12.0.0 of balsamic.

## Changes in the latest release of balsamic for reference:

**Added:**
- PIP specific missing tools to config https://github.com/Clinical-Genomics/BALSAMIC/pull/1096
- Filtering script to remove normal variants from TIDDIT feat: add TIDDIT tumor normal filtering  #1120
- Store TMB files in HK https://github.com/Clinical-Genomics/BALSAMIC/pull/1144

**Changed:**
- Fixed all conda container dependencies https://github.com/Clinical-Genomics/BALSAMIC/pull/1096
- Changed --max_sv_size in VEP params to the size of chr1 for hg19 https://github.com/Clinical-Genomics/BALSAMIC/pull/1124
- Increased time-limit for sambamba_exon_depth and picard_markduplicates to 6 hours https://github.com/Clinical-Genomics/BALSAMIC/pull/1143
- Update cosmicdb to v97 perf: COSMIC database to v97  #1147

**Fixed:**
- Update cryptography version (39.0.1) due to security alert https://github.com/Clinical-- Genomics/BALSAMIC/pull/1087
- Pytest file saved in balsamic directory fix: no more pytest generated files in my directory  #1093
- Fix varcall_py3 container bcftools dependency error https://github.com/Clinical-Genomics/BALSAMIC/pull/1097

## Changes in the read the docs made here:

**Added:**
- Descriptions of which filters were added in WGS T / N for TIDDIT normal filtering
- Update about maximum sv-size for VEP annotation

**Removed:**
- WGS from list of sequencing types where VarDict is used (just a correction)

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
