### PR TITLE
fix: Update tools versions for balsamic init

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changed:
 Fixed:
 ^^^^^^
 * Update cryptography version (39.0.1) due to security alert https://github.com/Clinical-Genomics/BALSAMIC/pull/1087
-* Bump cryptography to v40.0.2 and gsutil to v5.23 https://github.com/Clinical-Genomics/BALSAMIC/pull/1153
+* Bump cryptography to v40.0.2 and gsutil to v5.23 https://github.com/Clinical-Genomics/BALSAMIC/pull/1154
 * Pytest file saved in balsamic directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1093
 * Fix varcall_py3 container bcftools dependency error https://github.com/Clinical-Genomics/BALSAMIC/pull/1097
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed:
 Fixed:
 ^^^^^^
 * Update cryptography version (39.0.1) due to security alert https://github.com/Clinical-Genomics/BALSAMIC/pull/1087
+* Bump cryptography to v40.0.2 and gsutil to v5.23 https://github.com/Clinical-Genomics/BALSAMIC/pull/1153
 * Pytest file saved in balsamic directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1093
 * Fix varcall_py3 container bcftools dependency error https://github.com/Clinical-Genomics/BALSAMIC/pull/1097
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "colorclass>=2.2.0",
     "coloredlogs>=14.0",
     "graphviz==0.16",
-    "gsutil==4.50",
+    "gsutil==5.23",
     "jinja2>=2.11.2",
     "matplotlib==3.5.2",
     "networkx>=2.6.3",
@@ -30,7 +30,7 @@ requirements = [
     "h5py>=3.6.0",
     "PyPDF2>=1.26.0",
     "markdown==3.3.3",
-    "cryptography==39.0.1",
+    "cryptography==40.0.2",
     "tabulate==0.8.10",
     "toml==0.10.2",
 ]


### PR DESCRIPTION
### This PR:

Balsamic init was not able to download reference files from GS.

Cryptography version update was not compatible with pyOpenssL:
<img width="1221" alt="Screenshot 2023-05-03 at 15 18 10" src="https://user-images.githubusercontent.com/26309194/236197962-8f3970bf-3d9f-476a-864d-06a5d9b3cfef.png">


### Fixed:
* Bump cryptography to v40.0.2 and gsutil to v5.23



### Review and tests: 
- [x] Tests pass <img width="749" alt="Screenshot 2023-05-03 at 15 17 56" src="https://user-images.githubusercontent.com/26309194/236197958-d48bd75e-2eb5-4a79-af43-42224e7f720c.png">
- [x] The cache has been succsefully built
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
