### PR TITLE
fix: pydantic version to <2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changed:
 ^^^^^^^^
 * Updated snakemake version to 7.25.0 https://github.com/Clinical-Genomics/BALSAMIC/pull/1099
 * Updated cryptography version to 41.0.1 https://github.com/Clinical-Genomics/BALSAMIC/pull/1173
+* Fix pydantic version (<2.0) https://github.com/Clinical-Genomics/BALSAMIC/pull/1191
 
 Fixed:
 ^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy>=1.21.6",
     "pandas>=1.1.5",
     "psutil>=5.7.0",
-    "pydantic>=1.9.0",
+    "pydantic<2.0",
     "pygments>=2.6.1",
     "pyyaml>=5.3.1",
     "six>=1.12.0",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy>=1.21.6",
     "pandas>=1.1.5",
     "psutil>=5.7.0",
-    "pydantic<2.0",
+    "pydantic>=1.9.0,<2.0",
     "pygments>=2.6.1",
     "pyyaml>=5.3.1",
     "six>=1.12.0",


### PR DESCRIPTION
### This PR:

Pydantic v2, which introduced breaking changes, has been released: https://github.com/pydantic/pydantic/releases/tag/v2.0,  causing pytest and model misbehaviour.

### Changed:
- Fix Pydantic version (<2.0)

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
