### PR TITLE
fix: Link external fastqs to case folder & create case directory

### DIFF
--- a/BALSAMIC/commands/config/case.py
+++ b/BALSAMIC/commands/config/case.py
@@ -1,23 +1,24 @@
-import os
 import json
 import logging
+import os
 from pathlib import Path
 
 import click
 
 from BALSAMIC import __version__ as balsamic_version
-from BALSAMIC.utils.cli import (
-    get_sample_dict,
-    get_panel_chrom,
-    get_bioinfo_tools_version,
-    generate_graph,
-)
 from BALSAMIC.constants.common import (
     CONTAINERS_CONDA_ENV_PATH,
     BIOINFO_TOOL_ENV,
     GENDER_OPTIONS,
 )
 from BALSAMIC.constants.workflow_params import VCF_DICT
+from BALSAMIC.utils.cli import (
+    get_sample_dict,
+    get_panel_chrom,
+    get_bioinfo_tools_version,
+    generate_graph,
+    get_analysis_fastq_files_directory,
+)
 from BALSAMIC.utils.io import write_json
 from BALSAMIC.utils.models import BalsamicConfigModel
 
@@ -248,7 +249,9 @@ def case_config(
             "case_id": case_id,
             "gender": gender,
             "analysis_dir": analysis_dir,
-            "fastq_path": fastq_path,
+            "fastq_path": get_analysis_fastq_files_directory(
+                case_dir=Path(analysis_dir, case_id).as_posix(), fastq_path=fastq_path
+            ),
             "analysis_type": "paired" if normal_sample_name else "single",
             "sequencing_type": "targeted" if panel_bed else "wgs",
             "analysis_workflow": analysis_workflow,

--- a/BALSAMIC/commands/config/pon.py
+++ b/BALSAMIC/commands/config/pon.py
@@ -10,6 +10,7 @@ from BALSAMIC.utils.cli import (
     generate_graph,
     get_bioinfo_tools_version,
     get_pon_sample_dict,
+    get_analysis_fastq_files_directory,
 )
 from BALSAMIC.utils.io import write_json
 from BALSAMIC.utils.models import PonBalsamicConfigModel
@@ -117,6 +118,10 @@ def pon_config(
     )
     with open(reference_config, "r") as f:
         reference_dict = json.load(f)["reference"]
+
+    fastq_path: str = get_analysis_fastq_files_directory(
+        case_dir=Path(analysis_dir, case_id).as_posix(), fastq_path=fastq_path
+    )
 
     config_collection_dict = PonBalsamicConfigModel(
         QC={

--- a/BALSAMIC/commands/run/analysis.py
+++ b/BALSAMIC/commands/run/analysis.py
@@ -14,7 +14,7 @@ from BALSAMIC.utils.cli import (
     SnakeMake,
     get_config,
     job_id_dump_to_yaml,
-    get_fastq_files_directory,
+    get_resolved_fastq_files_directory,
 )
 from BALSAMIC.constants.common import BALSAMIC_SCRIPTS
 from BALSAMIC.constants.workflow_params import VCF_DICT
@@ -219,7 +219,9 @@ def analysis(
 
     # Singularity bind path
     bind_path = list()
-    bind_path.append(get_fastq_files_directory(sample_config["analysis"]["fastq_path"]))
+    bind_path.append(
+        get_resolved_fastq_files_directory(sample_config["analysis"]["fastq_path"])
+    )
     bind_path.append(str(Path(__file__).parents[2] / "assets"))
     bind_path.append(os.path.commonpath(sample_config["reference"].values()))
     if "panel" in sample_config:

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -572,6 +572,13 @@ def get_analysis_fastq_files_directory(case_dir: str, fastq_path: str) -> str:
     analysis_fastq_path.mkdir(parents=True, exist_ok=True)
     if Path(case_dir) not in Path(fastq_path).parents:
         for fastq in Path(fastq_path).glob("*.fastq.gz"):
-            Path(analysis_fastq_path, fastq.name).symlink_to(fastq)
+            try:
+                Path(analysis_fastq_path, fastq.name).symlink_to(fastq)
+                LOG.info(f"Created link for {fastq} in {analysis_fastq_path}")
+            except FileExistsError:
+                LOG.warning(
+                    f"File {Path(analysis_fastq_path, fastq.name)} exists. Skipping linking."
+                )
+
         return analysis_fastq_path.as_posix()
     return fastq_path

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -1,22 +1,20 @@
-import os
-import shutil
 import logging
-import sys
+import os
 import re
 import subprocess
-from pathlib import Path
-from io import StringIO
-from distutils.spawn import find_executable
+import sys
 import zlib
+from distutils.spawn import find_executable
+from io import StringIO
+from pathlib import Path
 from typing import Dict, Optional, List
 
-import yaml
-import snakemake
 import graphviz
+import snakemake
+import yaml
 from colorclass import Color
 
 from BALSAMIC import __version__ as balsamic_version
-from BALSAMIC.utils.exc import BalsamicError
 
 LOG = logging.getLogger(__name__)
 
@@ -558,7 +556,7 @@ def create_md5(reference, check_md5):
                 fh.write(get_md5(value) + " " + value + "\n")
 
 
-def get_fastq_files_directory(directory: str) -> str:
+def get_resolved_fastq_files_directory(directory: str) -> str:
     """Return the absolute path for the directory containing the input fastq files."""
     input_files: List[Path] = [
         file.absolute() for file in Path(directory).glob("*.fastq.gz")
@@ -566,3 +564,14 @@ def get_fastq_files_directory(directory: str) -> str:
     if not input_files or not input_files[0].is_symlink():
         return directory
     return os.path.commonpath([file.resolve().as_posix() for file in input_files])
+
+
+def get_analysis_fastq_files_directory(case_dir: str, fastq_path: str) -> str:
+    """Return analysis fastq directory, linking the fastq files if necessary."""
+    analysis_fastq_path: Path = Path(case_dir, "fastq")
+    analysis_fastq_path.mkdir(parents=True, exist_ok=True)
+    if case_dir not in fastq_path:
+        for fastq in Path(fastq_path).glob("*.fastq.gz"):
+            Path(analysis_fastq_path, fastq.name).symlink_to(fastq)
+        return analysis_fastq_path.as_posix()
+    return fastq_path

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -570,7 +570,7 @@ def get_analysis_fastq_files_directory(case_dir: str, fastq_path: str) -> str:
     """Return analysis fastq directory, linking the fastq files if necessary."""
     analysis_fastq_path: Path = Path(case_dir, "fastq")
     analysis_fastq_path.mkdir(parents=True, exist_ok=True)
-    if case_dir not in fastq_path:
+    if Path(case_dir) not in Path(fastq_path).parents:
         for fastq in Path(fastq_path).glob("*.fastq.gz"):
             Path(analysis_fastq_path, fastq.name).symlink_to(fastq)
         return analysis_fastq_path.as_posix()

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed:
 Fixed:
 ^^^^^^
 * vcf2cytosure container https://github.com/Clinical-Genomics/BALSAMIC/pull/1159
+* Link external fastqs to case folder & create case directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1195
 
 [12.0.1]
 --------

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -989,6 +989,31 @@ def test_get_analysis_fastq_files_directory(fastq_dir: str):
     assert input_dir == fastq_dir
 
 
+def test_get_analysis_fastq_files_directory_exception(
+    fastq_dir: str,
+    case_id_tumor_only,
+    tmp_path_factory: TempPathFactory,
+    caplog: LogCaptureFixture,
+):
+    """Test get analysis fastq directory when it already exists in case folder but another path is provided."""
+    caplog.set_level(logging.INFO)
+
+    # GIVEN an input fastq path and an external case directory
+    case_dir: str = tmp_path_factory.mktemp(case_id_tumor_only).as_posix()
+
+    # WHEN getting the analysis fastq directory twice
+    _input_dir: str = get_analysis_fastq_files_directory(
+        case_dir=case_dir, fastq_path=fastq_dir
+    )
+    input_dir: str = get_analysis_fastq_files_directory(
+        case_dir=case_dir, fastq_path=fastq_dir
+    )
+
+    # THEN the fastq directory should be located inside the case directory and the linking should have been skipped
+    assert input_dir == Path(case_dir, "fastq").as_posix()
+    assert "Skipping linking" in caplog.text
+
+
 def test_get_analysis_fastq_files_directory_no_fastqs(
     fastq_dir: str, tmp_path_factory: TempPathFactory, case_id_tumor_only: str
 ):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 
 from _pytest.logging import LogCaptureFixture
+from _pytest.tmpdir import TempPathFactory
 
 from BALSAMIC import __version__ as balsamic_version
 from BALSAMIC.utils.exc import BalsamicError, WorkflowRunError
@@ -39,7 +40,8 @@ from BALSAMIC.utils.cli import (
     create_md5,
     get_sample_dict,
     get_pon_sample_dict,
-    get_fastq_files_directory,
+    get_resolved_fastq_files_directory,
+    get_analysis_fastq_files_directory,
 )
 from BALSAMIC.utils.io import read_json, write_json, read_yaml
 
@@ -945,27 +947,66 @@ def test_get_pon_sample_dict(
     assert samples == samples_expected
 
 
-def test_get_fastq_files_directory(fastq_dir: str):
-    """Test get unlinked input files directory."""
+def test_get_resolved_fastq_files_directory(fastq_dir: str):
+    """Test get fastq directory for unlinked fastqs."""
 
-    # GIVEN an input fast path
+    # GIVEN an input fastq path
 
     # WHEN  extracting the input files common path
-    input_directory: str = get_fastq_files_directory(fastq_dir)
+    input_dir: str = get_resolved_fastq_files_directory(fastq_dir)
 
     # THEN the fastq directory should be returned
-    assert input_directory == fastq_dir
+    assert input_dir == fastq_dir
 
 
-def test_get_input_symlinked_files_path(fastq_dir: str, tmp_path: Path):
-    """Test remove symlinks from a directory."""
+def test_get_resolved_fastq_files_directory_symlinked_files(
+    fastq_dir: str, tmp_path: Path
+):
+    """Test get fastq directory for symlinked files."""
 
     # GIVEN a temporary fast path containing symlinked files
     for file in Path(fastq_dir).iterdir():
         Path(tmp_path, file.name).symlink_to(file)
 
     # WHEN  extracting the input files common path
-    input_directory: str = get_fastq_files_directory(str(tmp_path))
+    input_dir: str = get_resolved_fastq_files_directory(str(tmp_path))
 
     # THEN the real fastq directory should be returned
-    assert input_directory == fastq_dir
+    assert input_dir == fastq_dir
+
+
+def test_get_analysis_fastq_files_directory(fastq_dir: str):
+    """Test get analysis fastq directory when it already exists in case folder."""
+
+    # GIVEN an input fastq path
+
+    # WHEN getting the analysis fastq directory
+    input_dir: str = get_analysis_fastq_files_directory(
+        case_dir=Path(fastq_dir).parents[1].as_posix(), fastq_path=fastq_dir
+    )
+
+    # THEN the original fastq directory should be returned
+    assert input_dir == fastq_dir
+
+
+def test_get_analysis_fastq_files_directory_no_fastqs(
+    fastq_dir: str, tmp_path_factory: TempPathFactory, case_id_tumor_only: str
+):
+    """Test get analysis fastq directory when the provided fastq directory is outside the case folder."""
+
+    # GIVEN an external input fastq path and a case directory
+    case_dir: str = tmp_path_factory.mktemp(case_id_tumor_only).as_posix()
+
+    # WHEN getting the analysis fastq directory
+    input_dir: str = get_analysis_fastq_files_directory(
+        case_dir=case_dir, fastq_path=fastq_dir
+    )
+
+    # THEN the fastq directory should be located inside the case directory
+    assert input_dir == Path(case_dir, "fastq").as_posix()
+
+    # THEN the case fast files should have been linked to the provided fastq directory
+    for fastq in Path(input_dir).iterdir():
+        assert fastq.is_symlink()
+        assert fastq.resolve().is_file()
+        assert fastq_dir == fastq.resolve().parent.as_posix()


### PR DESCRIPTION
### This PR:

During testing, it was discovered that the `balsamic config case` command failed when the provided FASTQ directory was outside the case folder. This issue was not encountered when the command was run through CG, as CG creates and links the necessary files in the case directory. 

To ensure that the command works as expected in all scenarios, the code has been modified to create the case directory if it does not exist and link the fastq files from the provided fastq directory.

### Review and tests: 
- [x] Tests pass
  - [x] FASTQ linked when an external fastq directory is provided
  <img width="1111" alt="Screenshot 2023-07-11 at 15 56 13" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/f996c92e-bfcf-44ab-9886-ce0d118a8231">
  <img width="1111" alt="Screenshot 2023-07-11 at 15 51 00" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/1093db4f-e092-4900-b0a3-14732c1861ba">
  - [x] If FASTQ folder exists inside case, return use that path
  <img width="1111" alt="Screenshot 2023-07-11 at 15 53 42" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/d2c031b6-5cc6-48aa-8aa7-b74befceb5b7">


- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
