### PR TITLE
fix: vcf2cytosure container missing constants

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,9 +1,9 @@
 name: Build and push master and develop container
 on:
   push:
-    branches:
-      - master
-      - develop
+#    branches:
+#      - master
+#      - develop
 jobs:
   main:
     name: Docker image build push

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,9 +1,9 @@
 name: Build and push master and develop container
 on:
   push:
-#    branches:
-#      - master
-#      - develop
+    branches:
+      - master
+      - develop
 jobs:
   main:
     name: Docker image build push

--- a/BALSAMIC/containers/vcf2cytosure/Dockerfile
+++ b/BALSAMIC/containers/vcf2cytosure/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS builder
+FROM python:3.11.3-slim AS builder
 
 ARG CONTAINER_NAME
 ENV WORK_DIR /opt/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Fixed:
 ^^^^^^
 * vcf2cytosure container https://github.com/Clinical-Genomics/BALSAMIC/pull/1159
 * Link external fastqs to case folder & create case directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1195
-
+* vcf2cytosure container missing constants https://github.com/Clinical-Genomics/BALSAMIC/pull/11
 [12.0.1]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed:
 * vcf2cytosure container https://github.com/Clinical-Genomics/BALSAMIC/pull/1159
 * Link external fastqs to case folder & create case directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1195
 * vcf2cytosure container missing constants https://github.com/Clinical-Genomics/BALSAMIC/pull/11
+
 [12.0.1]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Fixed:
 ^^^^^^
 * vcf2cytosure container https://github.com/Clinical-Genomics/BALSAMIC/pull/1159
 * Link external fastqs to case folder & create case directory https://github.com/Clinical-Genomics/BALSAMIC/pull/1195
-* vcf2cytosure container missing constants https://github.com/Clinical-Genomics/BALSAMIC/pull/11
+* vcf2cytosure container missing constants https://github.com/Clinical-Genomics/BALSAMIC/pull/1198
 
 [12.0.1]
 --------


### PR DESCRIPTION
### This PR:


Fixed: vcf2cytosure missing constants by fixing python version to 3.11.3. Python 3.11.4 caused the error.

### Review and tests: 
- [x] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
