### PR TITLE
fix: Balsamic container & pytests (fix cyvcf2 version)

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,9 +1,9 @@
 name: Build and push master and develop container
 on:
   push:
-    branches:
-      - master
-      - develop
+#    branches:
+#      - master
+#      - develop
 jobs:
   main:
     name: Docker image build push

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,9 +1,9 @@
 name: Build and push master and develop container
 on:
   push:
-#    branches:
-#      - master
-#      - develop
+    branches:
+      - master
+      - develop
 jobs:
   main:
     name: Docker image build push

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 [12.0.2]
 --------
 
-Fixed:
-^^^^^^
+Changed:
+^^^^^^^^
 * Fix cyvcf2 to version 0.30.22 https://github.com/Clinical-Genomics/BALSAMIC/pull/1206
 
 [12.0.1]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+[12.0.2]
+--------
+
+Fixed:
+^^^^^^
+* Fix cyvcf2 to version 0.30.22 https://github.com/Clinical-Genomics/BALSAMIC/pull/1206
+
 [12.0.1]
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 Changed:
 ^^^^^^^^
 * Fix cyvcf2 to version 0.30.22 https://github.com/Clinical-Genomics/BALSAMIC/pull/1206
+* Fix pydantic version (<2.0) https://github.com/Clinical-Genomics/BALSAMIC/pull/1206
 
 [12.0.1]
 --------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy>=1.21.6",
     "pandas>=1.1.5",
     "psutil>=5.7.0",
-    "pydantic>=1.9.0",
+    "pydantic<2.0",
     "pygments>=2.6.1",
     "pyyaml>=5.3.1",
     "six>=1.12.0",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = [
 
 # The C libraries required to build numpy are not available on RTD
 if not os.getenv("READTHEDOCS"):
-    requirements.extend(["cyvcf2<0.10.0"])
+    requirements.extend(["cyvcf2==0.30.22"])
 
 setup(
     name="BALSAMIC",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy>=1.21.6",
     "pandas>=1.1.5",
     "psutil>=5.7.0",
-    "pydantic<2.0",
+    "pydantic>=1.9.0,<2.0",
     "pygments>=2.6.1",
     "pyyaml>=5.3.1",
     "six>=1.12.0",


### PR DESCRIPTION
### This PR:

The recent Cython update to v0.30 has led to compilation errors, resulting in the failure to execute the Balsamic container and, more importantly, preventing pytest from running via GitHub actions.

<img width="1045" alt="Screenshot 2023-07-19 at 14 51 37" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/29ce4be8-7961-46cc-a6f7-c90c1c759fef">

### Changed:
- Fix cyvcf2 to version 0.30.22

### Review and tests: 
- [x] Tests pass
  <img width="562" alt="Screenshot 2023-07-20 at 13 40 04" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/4ac189ac-cd73-4dab-93b9-441232f853cb">
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
