### PR TITLE
feat: Enable Conda Environment Usage in Rules

### DIFF
--- a/BALSAMIC/commands/config/case.py
+++ b/BALSAMIC/commands/config/case.py
@@ -31,6 +31,7 @@ from BALSAMIC.commands.options import (
     OPTION_UMI,
     OPTION_UMI_TRIM_LENGTH,
     OPTION_CACHE_VERSION,
+    OPTION_CONDA_ENV,
 )
 from BALSAMIC.constants.analysis import BIOINFO_TOOL_ENV, Gender, AnalysisWorkflow
 from BALSAMIC.constants.cache import GenomeVersion
@@ -65,6 +66,7 @@ LOG = logging.getLogger(__name__)
 @OPTION_CASE_ID
 @OPTION_CLINICAL_SNV_OBSERVATIONS
 @OPTION_CLINICAL_SV_OBSERVATIONS
+@OPTION_CONDA_ENV
 @OPTION_FASTQ_PATH
 @OPTION_GENDER
 @OPTION_GENOME_VERSION
@@ -93,6 +95,7 @@ def case_config(
     case_id: str,
     clinical_snv_observations: Path,
     clinical_sv_observations: Path,
+    conda_env: str,
     fastq_path: Path,
     gender: Gender,
     genome_version: GenomeVersion,
@@ -150,6 +153,7 @@ def case_config(
             "analysis_type": "paired" if normal_sample_name else "single",
             "sequencing_type": "targeted" if panel_bed else "wgs",
             "analysis_workflow": analysis_workflow,
+            "conda_env": conda_env,
         },
         reference=references,
         singularity={

--- a/BALSAMIC/commands/config/pon.py
+++ b/BALSAMIC/commands/config/pon.py
@@ -20,6 +20,7 @@ from BALSAMIC.commands.options import (
     OPTION_UMI,
     OPTION_UMI_TRIM_LENGTH,
     OPTION_CACHE_VERSION,
+    OPTION_CONDA_ENV,
 )
 from BALSAMIC.constants.analysis import BIOINFO_TOOL_ENV
 from BALSAMIC.constants.cache import GenomeVersion
@@ -44,6 +45,7 @@ LOG = logging.getLogger(__name__)
 @OPTION_BALSAMIC_CACHE
 @OPTION_CACHE_VERSION
 @OPTION_CASE_ID
+@OPTION_CONDA_ENV
 @OPTION_FASTQ_PATH
 @OPTION_GENOME_VERSION
 @OPTION_PANEL_BED
@@ -59,6 +61,7 @@ def pon_config(
     balsamic_cache: Path,
     cache_version: str,
     case_id: str,
+    conda_env: str,
     fastq_path: Path,
     genome_version: GenomeVersion,
     panel_bed: Path,
@@ -90,6 +93,7 @@ def pon_config(
             "pon_version": version,
             "analysis_workflow": "balsamic",
             "sequencing_type": "targeted" if panel_bed else "wgs",
+            "conda_env": conda_env,
         },
         samples=get_pon_sample_list(fastq_path),
         reference=references,

--- a/BALSAMIC/commands/options.py
+++ b/BALSAMIC/commands/options.py
@@ -22,7 +22,7 @@ from BALSAMIC.constants.cluster import (
 from BALSAMIC.constants.constants import LogLevel, LOG_LEVELS
 from BALSAMIC.constants.rules import DELIVERY_RULES
 from BALSAMIC.constants.workflow_params import VCF_DICT
-from BALSAMIC.utils.cli import validate_cache_version
+from BALSAMIC.utils.cli import validate_cache_version, get_current_conda_environment
 
 OPTION_ADAPTER_TRIM = click.option(
     "--adapter-trim/--no-adapter-trim",
@@ -125,6 +125,13 @@ OPTION_CLINICAL_SV_OBSERVATIONS = click.option(
     type=click.Path(exists=True, resolve_path=True),
     required=False,
     help="VCF path of clinical SV observations (WGS analysis workflow)",
+)
+
+OPTION_CONDA_ENV = click.option(
+    "--conda-env",
+    default=get_current_conda_environment,
+    type=click.STRING,
+    help="Conda environment name to use. If not provided, the current environment will be used by default.",
 )
 
 OPTION_CLUSTER_ACCOUNT = click.option(

--- a/BALSAMIC/commands/options.py
+++ b/BALSAMIC/commands/options.py
@@ -129,7 +129,8 @@ OPTION_CLINICAL_SV_OBSERVATIONS = click.option(
 
 OPTION_CONDA_ENV = click.option(
     "--conda-env",
-    default=get_current_conda_environment,
+    default=get_current_conda_environment(),
+    show_default=True,
     type=click.STRING,
     help="Conda environment name to use. If not provided, the current environment will be used by default.",
 )

--- a/BALSAMIC/models/analysis.py
+++ b/BALSAMIC/models/analysis.py
@@ -230,6 +230,7 @@ class AnalysisModel(BaseModel):
         dag : Field(optional); Path where DAG graph of workflow will be stored
         BALSAMIC_version  : Field(optional); Current version of BALSAMIC
         config_creation_date  : Field(optional); Timestamp when config was created
+        conda_env : Field(required); Conda environment to run the analysis in
 
     Raises:
         ValueError:
@@ -254,6 +255,7 @@ class AnalysisModel(BaseModel):
     BALSAMIC_version: str = balsamic_version
     config_creation_date: Optional[str]
     pon_version: Optional[str]
+    conda_env: str
 
     class Config:
         validate_all = True

--- a/BALSAMIC/models/snakemake.py
+++ b/BALSAMIC/models/snakemake.py
@@ -166,7 +166,7 @@ class SnakemakeExecutable(BaseModel):
     def get_command(self) -> str:
         """Return Snakemake command to be submitted."""
         snakemake_command: str = (
-            f"snakemake --notemp -p --rerun-trigger mtime "
+            f"snakemake --notemp -p --rerun-trigger mtime --use-conda "
             f"--directory {self.working_dir.as_posix()} "
             f"--snakefile {self.snakefile.as_posix()} "
             f"{self.get_config_files_option()} "

--- a/BALSAMIC/snakemake_rules/concatenation/concatenation.rule
+++ b/BALSAMIC/snakemake_rules/concatenation/concatenation.rule
@@ -17,6 +17,8 @@ rule concatenate:
         fastq_dir = fastq_dir,
         sample = "{sample}",
         read = "{read}"
+    conda:
+        config_model.analysis.conda_env
     threads:
         get_threads(cluster_config, "concatenate")
     message:

--- a/BALSAMIC/snakemake_rules/quality_control/qc_metrics.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/qc_metrics.rule
@@ -24,6 +24,8 @@ rule collect_custom_qc_metrics:
         config_path = f"{analysis_dir_home}/{case_id}/{case_id}.json",
         collect_qc_metrics_script = get_script_path("collect_qc_metrics.py"),
         housekeeper_id = {"id": config["analysis"]["case_id"], "tags": "qc-metrics"}
+    conda:
+        config_model.analysis.conda_env
     threads:
         get_threads(cluster_config, "collect_custom_qc_metrics")
     message:

--- a/BALSAMIC/snakemake_rules/quality_control/report.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/report.rule
@@ -11,6 +11,8 @@ rule cnv_report:
         cnv_report_script= get_script_path("generate_cnv_report.py"),
     threads:
         get_threads(cluster_config, "cnv_report")
+    conda:
+        config_model.analysis.conda_env
     message:
         "Generating CNV report PDF"
     shell:

--- a/BALSAMIC/snakemake_rules/umi/concatenation_umi.rule
+++ b/BALSAMIC/snakemake_rules/umi/concatenation_umi.rule
@@ -18,6 +18,8 @@ rule concatenate_umi_reads:
     params:
         fastq_dir=config["analysis"]["fastq_path"],
         sample="{sample}",
+    conda:
+        config_model.analysis.conda_env
     threads:
         get_threads(cluster_config, "concatenate")
     message:

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -495,7 +495,7 @@ def validate_cache_version(
 
 def get_current_conda_environment() -> str:
     """Return current conda environment."""
-    conda_env = os.environ.get("CONDA_DEFAULT_ENV")
+    conda_env: str = os.environ.get("CONDA_DEFAULT_ENV")
     if conda_env:
         return conda_env
     raise click.UsageError(

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -491,3 +491,13 @@ def validate_cache_version(
     raise click.BadParameter(
         f"Invalid cache version format. Use '{CacheVersion.DEVELOP}' or 'X.X.X'."
     )
+
+
+def get_current_conda_environment() -> str:
+    """Return current conda environment."""
+    conda_env = os.environ.get("CONDA_DEFAULT_ENV")
+    if conda_env:
+        return conda_env
+    raise click.UsageError(
+        "Could not determine the current conda environment. Make sure you are using conda."
+    )

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Added:
 * Add cache version option to config case https://github.com/Clinical-Genomics/BALSAMIC/pull/1244
 * `cnvkit` container https://github.com/Clinical-Genomics/BALSAMIC/pull/1252
 * `PureCN` container https://github.com/Clinical-Genomics/BALSAMIC/pull/1255
+* Support for using Conda environments within rules https://github.com/Clinical-Genomics/BALSAMIC/pull/1263
 
 Changed:
 ^^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,11 @@ import shutil
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Generator
 from unittest import mock
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempPathFactory
 from click.testing import CliRunner
 
@@ -2192,3 +2193,17 @@ def fixture_snakemake_executable_validated_data(
         "snakemake_options": snakemake_options_command,
         "working_dir": session_tmp_path,
     }
+
+
+@pytest.fixture(scope="session")
+def conda_env() -> str:
+    """Test conda environment."""
+    return "test_environment"
+
+
+@pytest.fixture
+def set_conda_env_var(conda_env: str, monkeypatch: MonkeyPatch) -> Generator:
+    """A fixture to set the CONDA_DEFAULT_ENV environment variable temporarily."""
+    monkeypatch.setenv("CONDA_DEFAULT_ENV", "test_environment")
+    yield
+    monkeypatch.delenv("CONDA_DEFAULT_ENV")

--- a/tests/models/test_analysis_models.py
+++ b/tests/models/test_analysis_models.py
@@ -97,7 +97,7 @@ def test_varcaller_attribute():
     assert "unacceptable is not not a valid mutation class" in str(excinfo.value)
 
 
-def test_analysis_model(test_data_dir: str):
+def test_analysis_model(test_data_dir: str, conda_env: str):
     """Test analysis model instantiation."""
 
     # GIVEN valid input arguments
@@ -109,6 +109,7 @@ def test_analysis_model(test_data_dir: str):
         "analysis_dir": test_data_dir,
         "fastq_path": test_data_dir,
         "analysis_workflow": "balsamic-umi",
+        "conda_env": conda_env,
     }
 
     # THEN we can successfully create a config dict
@@ -277,7 +278,7 @@ def test_params_vep():
     assert test_vep_built.vep_filters == "all defaults params"
 
 
-def test_analysis_model_for_pon(test_data_dir: str):
+def test_analysis_model_for_pon(test_data_dir: str, conda_env: str):
     """Tests PON model parsing."""
 
     # GIVEN valid input arguments
@@ -289,6 +290,7 @@ def test_analysis_model_for_pon(test_data_dir: str):
         "fastq_path": test_data_dir,
         "analysis_workflow": "balsamic",
         "pon_version": "v1",
+        "conda_env": conda_env,
     }
 
     # THEN we can successfully create a config dict

--- a/tests/models/test_snakemake_models.py
+++ b/tests/models/test_snakemake_models.py
@@ -244,7 +244,7 @@ def test_get_snakemake_command(
     # THEN the expected format should be returned
     assert (
         snakemake_command
-        == f"snakemake --notemp -p --rerun-trigger mtime --directory {session_tmp_path.as_posix()} "
+        == f"snakemake --notemp -p --rerun-trigger mtime --use-conda --directory {session_tmp_path.as_posix()} "
         f"--snakefile {reference_file.as_posix()} "
         f"--configfiles {reference_file.as_posix()} {reference_file.as_posix()} "
         f"--use-singularity --singularity-args '--cleanenv --bind {session_tmp_path.as_posix()}:/' --quiet "

--- a/tests/test_data/config.json
+++ b/tests/test_data/config.json
@@ -209,6 +209,7 @@
         "log": "placeholder/logs/",
         "result": "placeholder/analysis/",
         "benchmark": "placeholder/benchmarks/",
+        "conda_env": "test_environment",
         "config_creation_date": "yyyy-mm-dd xx",
         "BALSAMIC_version": "12.0.2",
         "dag": "tests/test_data/id1_analysis.json_BALSAMIC_12.0.2_graph.pdf"

--- a/tests/test_data/config_pon.json
+++ b/tests/test_data/config_pon.json
@@ -20,7 +20,7 @@
         "vep_dir": "tests/test_data/references/vep/",
         "refgene_bed": "tests/test_data/references/genome/refseq.flat.bed",
         "somalier_sites": "tests/test_data/references/variants/GRCh37.somalier.sites.vcf.gz"
-    },    
+    },
     "bioinfo_tools": {
         "bedtools": "align_qc",
         "bwa": "align_qc",
@@ -154,6 +154,7 @@
         "dag": "tests/test_data/id1/id1_BALSAMIC_12.0.2_graph.pdf",
         "BALSAMIC_version": "12.0.2",
         "config_creation_date": "2023-08-10 10:07",
-        "pon_version": "v5"
+        "pon_version": "v5",
+        "conda_env": "test_environment"
     }
 }


### PR DESCRIPTION
### This PR:

This feature enables users to specify Conda environments for individual rules.

Added:
- Support for using Conda environments within rules

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
