### PR TITLE
chore: Migrate Snakemake models to pydantic v2

### DIFF
--- a/BALSAMIC/models/snakemake.py
+++ b/BALSAMIC/models/snakemake.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Optional, List
 
-from pydantic.v1 import BaseModel, FilePath, DirectoryPath, validator
+from pydantic import BaseModel, FilePath, DirectoryPath, field_validator, Field
 
 from BALSAMIC.constants.analysis import RunMode
 from BALSAMIC.constants.cluster import ClusterMailType, QOS, ClusterProfile, MAX_JOBS
@@ -53,38 +53,38 @@ class SnakemakeExecutable(BaseModel):
 
     """
 
-    account: Optional[str]
+    account: Optional[str] = None
     benchmark: bool = False
     case_id: str
-    cluster_config_path: Optional[FilePath]
+    cluster_config_path: Optional[FilePath] = None
     config_path: FilePath
-    disable_variant_caller: Optional[str]
+    disable_variant_caller: Optional[str] = Field(default=None, validate_default=True)
     dragen: bool = False
     force: bool = False
-    log_dir: Optional[DirectoryPath]
-    mail_type: Optional[ClusterMailType]
-    mail_user: Optional[str]
-    profile: Optional[ClusterProfile]
-    qos: Optional[QOS]
+    log_dir: Optional[DirectoryPath] = None
+    mail_type: Optional[ClusterMailType] = None
+    mail_user: Optional[str] = Field(default=None, validate_default=True)
+    profile: Optional[ClusterProfile] = None
+    qos: Optional[QOS] = None
     quiet: bool = False
-    report_path: Optional[Path]
-    result_dir: Optional[DirectoryPath]
+    report_path: Optional[Path] = None
+    result_dir: Optional[DirectoryPath] = None
     run_analysis: bool = False
     run_mode: RunMode
-    script_dir: Optional[DirectoryPath]
-    singularity_bind_paths: Optional[List[SingularityBindPath]]
+    script_dir: Optional[DirectoryPath] = None
+    singularity_bind_paths: Optional[List[SingularityBindPath]] = None
     snakefile: FilePath
-    snakemake_options: Optional[List[str]]
+    snakemake_options: Optional[List[str]] = None
     working_dir: Path
 
-    @validator("disable_variant_caller", always=True)
+    @field_validator("disable_variant_caller")
     def get_disable_variant_caller_option(cls, disable_variant_caller: str) -> str:
         """Return string representation of the disable_variant_caller option."""
         if disable_variant_caller:
             return f"disable_variant_caller={disable_variant_caller}"
         return ""
 
-    @validator("mail_user", always=True)
+    @field_validator("mail_user")
     def get_mail_user_option(cls, mail_user: Optional[str]) -> str:
         """Return string representation of the mail_user option."""
         if mail_user:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Changed:
 * Reuse common Balsamic CLI options https://github.com/Clinical-Genomics/BALSAMIC/pull/1242
 * Update `reference.json` file to use relative paths https://github.com/Clinical-Genomics/BALSAMIC/pull/1251
 * Update pydantic to v2 while maintaining support for v1 models https://github.com/Clinical-Genomics/BALSAMIC/pull/1253
+* Migrate Snakemake models to pydantic v2 https://github.com/Clinical-Genomics/BALSAMIC/pull/1268
 
 Fixed:
 ^^^^^^

--- a/tests/models/test_snakemake_models.py
+++ b/tests/models/test_snakemake_models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 import pytest
-from pydantic.v1 import ValidationError
+from pydantic import ValidationError
 
 from BALSAMIC.constants.cluster import (
     ClusterMailType,
@@ -29,7 +29,7 @@ def test_singularity_bind_path_model(singularity_bind_path_data: Dict[str, Path]
     )
 
     # THEN the model should have been correctly built
-    assert singularity_bind_path_model.dict() == singularity_bind_path_data
+    assert dict(singularity_bind_path_model) == singularity_bind_path_data
 
 
 def test_snakemake_model(
@@ -46,7 +46,7 @@ def test_snakemake_model(
     )
 
     # THEN the model should have been correctly built
-    assert snakemake_model.dict() == snakemake_executable_validated_data
+    assert dict(snakemake_model) == snakemake_executable_validated_data
 
 
 def test_snakemake_model_empty():


### PR DESCRIPTION
### This PR:

#### Changed
- Migrate Snakemake models to pydantic v2

### Review and tests: 
- [x] Tests pass
  - [ ] Start analysis
  <img width="333" alt="Screenshot 2023-10-04 at 16 27 20" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/1b0bd7a7-54d1-4b27-a618-fcf4dcb26227">

  - [x] Resume analysis 
  <img width="666" alt="Screenshot 2023-10-04 at 16 26 34" src="https://github.com/Clinical-Genomics/BALSAMIC/assets/26309194/4b3f1c98-8293-4d9e-b0ad-9284a24750dd">

- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
