### PR TITLE
updated python requirement in install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Software Requirements
 
 - Conda >=version 4.5.0: For detailed software and python requirements please see ``setup.py`` and ``BALSAMIC/conda/balsamic.yaml``
 - Singularity >=version 3.0.0: BALSAMIC uses singularity to run vairous parts of the workflow. 
-- Python 3.6
+- Python 3.7
 - BALSAMIC is dependent on third-party bioinformatics software ``Sentieon-tools``. Example: for running wgs variant calling using ``TNScope``, and to execute ``UMIworkflow``.
 
 ``Note: Set Sentieon envionment variables in your ~/.bashrc file by adding following two lines``


### PR DESCRIPTION
### This PR:
Document update

### Reason for this PR:

- according to https://github.com/Clinical-Genomics/BALSAMIC/blob/master/docs/install.rst#step-1-installing-balsamic the python version recommended with conda is 3.7 but in the software requirement - session it says 3.6, this is the first place there is contradiction.
- most importantly, the evidence for 3.6 is not supported at all, is in setup.py https://github.com/Clinical-Genomics/BALSAMIC/blob/e85f45b84e20564c798ee5d8f58deb8086ee5c4f/setup.py#L13 the click version required is 8.1.3, but python3.6 only support click up to  8.0.4, if you install python3.6 and will not be able to upgrade click higher than 8.0.4 so this part of document is misleading 

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
