### PR TITLE
Added ability to reuse cache dir

### DIFF
--- a/BALSAMIC/commands/init/base.py
+++ b/BALSAMIC/commands/init/base.py
@@ -170,6 +170,13 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Instruct snakemake to be quiet! No output will be printed",
 )
+@click.option(
+    "-u",
+    "--unlock",
+    default=False,
+    is_flag=True,
+    help="Reuse balsamic cache directory. Remove a lock on the snakemake working directory",
+)
 @click.pass_context
 def initialize(
     context,
@@ -190,6 +197,7 @@ def initialize(
     mail_type,
     force_all,
     quiet,
+    unlock,
     snakemake_opt,
 ):
     """
@@ -319,6 +327,7 @@ def initialize(
     balsamic_run.result_path = reference_outdir
     balsamic_run.case_name = config_dict["analysis"]["case_id"]
     balsamic_run.quiet = quiet
+    balsamic_run.unlock = unlock
     if mail_type:
         balsamic_run.mail_type = mail_type
     balsamic_run.mail_user = mail_user

--- a/BALSAMIC/utils/cli.py
+++ b/BALSAMIC/utils/cli.py
@@ -60,6 +60,7 @@ class SnakeMake:
     use_singularity - To use singularity
     singularity_bind- Singularity bind path
     quiet           - Quiet mode for snakemake
+    unlock          - To reuse a cache directory
     singularity_arg - Singularity arguments to pass to snakemake
     sm_opt          - snakemake additional options
     disable_variant_caller - Disable variant caller
@@ -86,6 +87,7 @@ class SnakeMake:
         self.forceall = False
         self.run_analysis = False
         self.quiet = False
+        self.unlock = False
         self.report = str()
         self.use_singularity = True
         self.singularity_bind = str()
@@ -98,6 +100,7 @@ class SnakeMake:
     def build_cmd(self):
         forceall = str()
         quiet_mode = str()
+        unlock_cache_dir = str()
         sm_opt = str()
         cluster_cmd = str()
         dryrun = str()
@@ -112,6 +115,9 @@ class SnakeMake:
 
         if self.quiet:
             quiet_mode = " --quiet "
+
+        if self.unlock:
+            unlock_cache_dir = " --unlock "
 
         if self.sm_opt:
             sm_opt = " ".join(self.sm_opt)
@@ -180,7 +186,7 @@ class SnakeMake:
         sm_cmd = (
             f" snakemake --notemp -p "
             f" --directory {self.working_dir} --snakefile {self.snakefile} --configfiles {self.configfile} "
-            f" {self.cluster_config} {self.singularity_arg} {quiet_mode} "
+            f" {self.cluster_config} {self.singularity_arg} {quiet_mode} {unlock_cache_dir}"
             f" {forceall} {dryrun} {cluster_cmd} "
             f" {report} {snakemake_config_key_value} {sm_opt}"
         )


### PR DESCRIPTION
### This PR:

Added: for new features.

To Reproduce Error. If you chose a balsamic cache directory that was previously used (the reason you reuse a cache directory could be the old container pull was "interrupted" for some reason and you want to continue from there without starting over). With the current code, It will error out because snakemake is putting a lock to that directory. And the error is suggesting you can use --unlock but this flag is not accepted by balsamic. Thus adding it to be able to utilize --unlockflag from snakemake

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
