### PR TITLE
refactor: Use StrEnum from python enum 

### DIFF
--- a/BALSAMIC/commands/options.py
+++ b/BALSAMIC/commands/options.py
@@ -45,7 +45,7 @@ OPTION_ANALYSIS_DIR = click.option(
 OPTION_ANALYSIS_WORKFLOW = click.option(
     "-w",
     "--analysis-workflow",
-    default=AnalysisWorkflow.BALSAMIC.value,
+    default=AnalysisWorkflow.BALSAMIC,
     show_default=True,
     type=click.Choice(ANALYSIS_WORKFLOWS),
     help="Balsamic analysis workflow to be executed",
@@ -183,10 +183,10 @@ OPTION_DELIVERY_MODE = click.option(
     "-m",
     "--delivery-mode",
     type=click.Choice(RULE_DELIVERY_MODES),
-    default=RuleDeliveryMode.APPEND.value,
+    default=RuleDeliveryMode.APPEND,
     show_default=True,
-    help=f"Append rules to deliver to the current delivery option ({RuleDeliveryMode.APPEND.value}) or deliver only "
-    f"the ones specified ({RuleDeliveryMode.RESET.value})",
+    help=f"Append rules to deliver to the current delivery option ({RuleDeliveryMode.APPEND}) or deliver only "
+    f"the ones specified ({RuleDeliveryMode.RESET})",
 )
 
 OPTION_DISABLE_VARIANT_CALLER = click.option(
@@ -221,7 +221,7 @@ OPTION_GENDER = click.option(
     "--gender",
     required=False,
     type=click.Choice([Gender.FEMALE, Gender.MALE]),
-    default=Gender.FEMALE.value,
+    default=Gender.FEMALE,
     show_default=True,
     help="Sample associated gender",
 )
@@ -258,7 +258,7 @@ OPTION_GNOMAD_AF5 = click.option(
 
 OPTION_LOG_LEVEL = click.option(
     "--log-level",
-    default=LogLevel.INFO.value,
+    default=LogLevel.INFO,
     type=click.Choice(LOG_LEVELS),
     help="Logging level in terms of urgency",
     show_default=True,

--- a/BALSAMIC/constants/analysis.py
+++ b/BALSAMIC/constants/analysis.py
@@ -1,8 +1,8 @@
 """Balsamic analysis workflow constants."""
+from enum import StrEnum
 from typing import Dict, List
 
 from BALSAMIC.constants.cache import DockerContainers
-from BALSAMIC.utils.class_types import StrEnum
 
 
 class RunMode(StrEnum):

--- a/BALSAMIC/constants/analysis.py
+++ b/BALSAMIC/constants/analysis.py
@@ -12,7 +12,7 @@ class RunMode(StrEnum):
     LOCAL: str = "local"
 
 
-RUN_MODES: List[RunMode] = [mode.value for mode in RunMode]
+RUN_MODES: List[RunMode] = [mode for mode in RunMode]
 
 
 class Gender(StrEnum):
@@ -38,9 +38,7 @@ class AnalysisWorkflow(StrEnum):
     BALSAMIC_UMI: str = "balsamic-umi"
 
 
-ANALYSIS_WORKFLOWS: List[AnalysisWorkflow] = [
-    workflow.value for workflow in AnalysisWorkflow
-]
+ANALYSIS_WORKFLOWS: List[AnalysisWorkflow] = [workflow for workflow in AnalysisWorkflow]
 
 
 class SequencingType(StrEnum):
@@ -89,7 +87,7 @@ class PONWorkflow(StrEnum):
     GENS_FEMALE: str = "GENS_female"
 
 
-PON_WORKFLOWS: List[PONWorkflow] = [workflow.value for workflow in PONWorkflow]
+PON_WORKFLOWS: List[PONWorkflow] = [workflow for workflow in PONWorkflow]
 
 
 class RuleDeliveryMode(StrEnum):
@@ -99,7 +97,7 @@ class RuleDeliveryMode(StrEnum):
     RESET: str = "reset"
 
 
-RULE_DELIVERY_MODES: List[RuleDeliveryMode] = [mode.value for mode in RuleDeliveryMode]
+RULE_DELIVERY_MODES: List[RuleDeliveryMode] = [mode for mode in RuleDeliveryMode]
 
 
 class BioinfoTools(StrEnum):
@@ -157,34 +155,34 @@ class PonParams:
 
 
 BIOINFO_TOOL_ENV: Dict[str, str] = {
-    BioinfoTools.BEDTOOLS.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.BWA.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.COMPRESS.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.FASTQC.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.SAMTOOLS.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.PICARD.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.MULTIQC.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.FASTP.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.CSVKIT.value: DockerContainers.ALIGN_QC.value,
-    BioinfoTools.VEP.value: DockerContainers.ANNOTATE.value,
-    BioinfoTools.GENMOD.value: DockerContainers.ANNOTATE.value,
-    BioinfoTools.VCFANNO.value: DockerContainers.ANNOTATE.value,
-    BioinfoTools.SAMBAMBA.value: DockerContainers.COVERAGE_QC.value,
-    BioinfoTools.MOSDEPTH.value: DockerContainers.COVERAGE_QC.value,
-    BioinfoTools.BCFTOOLS.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.TABIX.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.BGZIP.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.VARDICT.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.SVDB.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.TIDDIT.value: DockerContainers.PYTHON_3.value,
-    BioinfoTools.CNVPYTOR.value: DockerContainers.CNVPYTOR.value,
-    BioinfoTools.MANTA.value: DockerContainers.PYTHON_27.value,
-    BioinfoTools.CNVKIT.value: DockerContainers.CNVKIT.value,
-    BioinfoTools.DELLY.value: DockerContainers.DELLY.value,
-    BioinfoTools.ASCAT.value: DockerContainers.ASCAT.value,
-    BioinfoTools.VCF2CYTOSURE.value: DockerContainers.VCF2CYTOSURE.value,
-    BioinfoTools.SOMALIER.value: DockerContainers.SOMALIER.value,
-    BioinfoTools.CADD.value: DockerContainers.CADD.value,
-    BioinfoTools.PURECN.value: DockerContainers.PURECN.value,
-    BioinfoTools.GATK.value: DockerContainers.GATK.value,
+    BioinfoTools.BEDTOOLS: DockerContainers.ALIGN_QC,
+    BioinfoTools.BWA: DockerContainers.ALIGN_QC,
+    BioinfoTools.COMPRESS: DockerContainers.ALIGN_QC,
+    BioinfoTools.FASTQC: DockerContainers.ALIGN_QC,
+    BioinfoTools.SAMTOOLS: DockerContainers.ALIGN_QC,
+    BioinfoTools.PICARD: DockerContainers.ALIGN_QC,
+    BioinfoTools.MULTIQC: DockerContainers.ALIGN_QC,
+    BioinfoTools.FASTP: DockerContainers.ALIGN_QC,
+    BioinfoTools.CSVKIT: DockerContainers.ALIGN_QC,
+    BioinfoTools.VEP: DockerContainers.ANNOTATE,
+    BioinfoTools.GENMOD: DockerContainers.ANNOTATE,
+    BioinfoTools.VCFANNO: DockerContainers.ANNOTATE,
+    BioinfoTools.SAMBAMBA: DockerContainers.COVERAGE_QC,
+    BioinfoTools.MOSDEPTH: DockerContainers.COVERAGE_QC,
+    BioinfoTools.BCFTOOLS: DockerContainers.PYTHON_3,
+    BioinfoTools.TABIX: DockerContainers.PYTHON_3,
+    BioinfoTools.BGZIP: DockerContainers.PYTHON_3,
+    BioinfoTools.VARDICT: DockerContainers.PYTHON_3,
+    BioinfoTools.SVDB: DockerContainers.PYTHON_3,
+    BioinfoTools.TIDDIT: DockerContainers.PYTHON_3,
+    BioinfoTools.CNVPYTOR: DockerContainers.CNVPYTOR,
+    BioinfoTools.MANTA: DockerContainers.PYTHON_27,
+    BioinfoTools.CNVKIT: DockerContainers.CNVKIT,
+    BioinfoTools.DELLY: DockerContainers.DELLY,
+    BioinfoTools.ASCAT: DockerContainers.ASCAT,
+    BioinfoTools.VCF2CYTOSURE: DockerContainers.VCF2CYTOSURE,
+    BioinfoTools.SOMALIER: DockerContainers.SOMALIER,
+    BioinfoTools.CADD: DockerContainers.CADD,
+    BioinfoTools.PURECN: DockerContainers.PURECN,
+    BioinfoTools.GATK: DockerContainers.GATK,
 }

--- a/BALSAMIC/constants/cache.py
+++ b/BALSAMIC/constants/cache.py
@@ -1,8 +1,8 @@
 """Balsamic cache specific constants."""
+from enum import StrEnum
 from typing import Dict, List
 
 from BALSAMIC.constants.constants import FileType
-from BALSAMIC.utils.class_types import StrEnum
 
 DOCKER_URL: str = "docker://clinicalgenomics/balsamic"
 VEP_PLUGINS: str = "all"

--- a/BALSAMIC/constants/cache.py
+++ b/BALSAMIC/constants/cache.py
@@ -16,7 +16,7 @@ class GenomeVersion(StrEnum):
     CanFam3: str = "canfam3"
 
 
-GENOME_VERSIONS: List[GenomeVersion] = [version.value for version in GenomeVersion]
+GENOME_VERSIONS: List[GenomeVersion] = [version for version in GenomeVersion]
 
 
 class GRCHVersion(StrEnum):

--- a/BALSAMIC/constants/cluster.py
+++ b/BALSAMIC/constants/cluster.py
@@ -19,7 +19,7 @@ class ClusterProfile(StrEnum):
     QSUB: str = "qsub"
 
 
-CLUSTER_PROFILES: List[ClusterProfile] = [profile.value for profile in ClusterProfile]
+CLUSTER_PROFILES: List[ClusterProfile] = [profile for profile in ClusterProfile]
 
 
 class ClusterAccount(StrEnum):
@@ -37,7 +37,7 @@ class QOS(StrEnum):
     EXPRESS: str = "express"
 
 
-QOS_OPTIONS: List[QOS] = [qos.value for qos in QOS]
+QOS_OPTIONS: List[QOS] = [qos for qos in QOS]
 
 
 class ClusterMailType(StrEnum):
@@ -52,4 +52,4 @@ class ClusterMailType(StrEnum):
     TIME_LIMIT: str = "TIME_LIMIT"
 
 
-CLUSTER_MAIL_TYPES: List[ClusterMailType] = [type.value for type in ClusterMailType]
+CLUSTER_MAIL_TYPES: List[ClusterMailType] = [mail_type for mail_type in ClusterMailType]

--- a/BALSAMIC/constants/cluster.py
+++ b/BALSAMIC/constants/cluster.py
@@ -1,8 +1,6 @@
 """Balsamic cluster and submission specific constants."""
+from enum import StrEnum
 from typing import List
-
-from BALSAMIC.utils.class_types import StrEnum
-
 
 MAX_JOBS: int = 999
 

--- a/BALSAMIC/constants/constants.py
+++ b/BALSAMIC/constants/constants.py
@@ -1,7 +1,6 @@
 """General use constants."""
+from enum import StrEnum
 from typing import List
-
-from BALSAMIC.utils.class_types import StrEnum
 
 EXIT_SUCCESS: int = 0
 EXIT_FAIL: int = 1

--- a/BALSAMIC/constants/constants.py
+++ b/BALSAMIC/constants/constants.py
@@ -16,7 +16,7 @@ class LogLevel(StrEnum):
     CRITICAL = "CRITICAL"
 
 
-LOG_LEVELS: List[LogLevel] = [level.value for level in LogLevel]
+LOG_LEVELS: List[LogLevel] = [level for level in LogLevel]
 
 
 class FileType(StrEnum):

--- a/BALSAMIC/models/snakemake.py
+++ b/BALSAMIC/models/snakemake.py
@@ -119,7 +119,7 @@ class SnakemakeExecutable(BaseModel):
     def get_mail_type_option(self) -> str:
         """Return string representation of the mail_type option."""
         if self.mail_type:
-            return f"--mail-type {self.mail_type.value}"
+            return f"--mail-type {self.mail_type}"
         return ""
 
     def get_quiet_flag(self) -> str:
@@ -198,9 +198,9 @@ class SnakemakeExecutable(BaseModel):
         cluster_submit_command: str = (
             f"'{sys.executable} {SCHEDULER_PATH.as_posix()} "
             f"--sample-config {self.config_path.as_posix()} "
-            f"--profile {self.profile.value} "
+            f"--profile {self.profile} "
             f"--account {self.account} "
-            f"--qos {self.qos.value} "
+            f"--qos {self.qos} "
             f"--log-dir {self.log_dir.as_posix()} "
             f"--script-dir {self.script_dir.as_posix()} "
             f"--result-dir {self.result_dir.as_posix()} "

--- a/BALSAMIC/utils/class_types.py
+++ b/BALSAMIC/utils/class_types.py
@@ -1,9 +1,0 @@
-"""Custom class types."""
-from enum import Enum
-
-
-class StrEnum(str, Enum):
-    """StrEnum data class."""
-
-    def __str__(self) -> str:
-        return str.__str__(self)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ Changed:
 * Migrate Snakemake models to pydantic v2 https://github.com/Clinical-Genomics/BALSAMIC/pull/1268
 * Migrate Cache models to pydantic v2 https://github.com/Clinical-Genomics/BALSAMIC/pull/1274
 * Made BALSAMIC compatible with multiple PON creation workflows https://github.com/Clinical-Genomics/BALSAMIC/pull/1279
+* Use StrEnum from python enum https://github.com/Clinical-Genomics/BALSAMIC/pull/1303
 
 
 Fixed:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1986,21 +1986,21 @@ def fixture_cosmic_key() -> str:
 def fixture_develop_containers() -> Dict[str, str]:
     """Return a dictionary of docker hub containers for develop branch."""
     return {
-        DockerContainers.ASCAT.value: "docker://clinicalgenomics/balsamic:develop-ascatNgs",
-        DockerContainers.VCF2CYTOSURE.value: "docker://clinicalgenomics/balsamic:develop-vcf2cytosure",
-        DockerContainers.PYTHON_3.value: "docker://clinicalgenomics/balsamic:develop-varcall_py3",
-        DockerContainers.SOMALIER.value: "docker://clinicalgenomics/balsamic:develop-somalier",
-        DockerContainers.CNVPYTOR.value: "docker://clinicalgenomics/balsamic:develop-cnvpytor",
-        DockerContainers.ALIGN_QC.value: "docker://clinicalgenomics/balsamic:develop-align_qc",
-        DockerContainers.ANNOTATE.value: "docker://clinicalgenomics/balsamic:develop-annotate",
-        DockerContainers.PYTHON_27.value: "docker://clinicalgenomics/balsamic:develop-varcall_py27",
-        DockerContainers.CNVKIT.value: "docker://clinicalgenomics/balsamic:develop-varcall_cnvkit",
-        DockerContainers.COVERAGE_QC.value: "docker://clinicalgenomics/balsamic:develop-coverage_qc",
-        DockerContainers.DELLY.value: "docker://clinicalgenomics/balsamic:develop-delly",
-        DockerContainers.CADD.value: "docker://clinicalgenomics/balsamic:develop-cadd",
-        DockerContainers.HTSLIB.value: "docker://clinicalgenomics/balsamic:develop-htslib",
-        DockerContainers.PURECN.value: "docker://clinicalgenomics/balsamic:develop-purecn",
-        DockerContainers.GATK.value: "docker://clinicalgenomics/balsamic:develop-gatk",
+        DockerContainers.ASCAT: "docker://clinicalgenomics/balsamic:develop-ascatNgs",
+        DockerContainers.VCF2CYTOSURE: "docker://clinicalgenomics/balsamic:develop-vcf2cytosure",
+        DockerContainers.PYTHON_3: "docker://clinicalgenomics/balsamic:develop-varcall_py3",
+        DockerContainers.SOMALIER: "docker://clinicalgenomics/balsamic:develop-somalier",
+        DockerContainers.CNVPYTOR: "docker://clinicalgenomics/balsamic:develop-cnvpytor",
+        DockerContainers.ALIGN_QC: "docker://clinicalgenomics/balsamic:develop-align_qc",
+        DockerContainers.ANNOTATE: "docker://clinicalgenomics/balsamic:develop-annotate",
+        DockerContainers.PYTHON_27: "docker://clinicalgenomics/balsamic:develop-varcall_py27",
+        DockerContainers.CNVKIT: "docker://clinicalgenomics/balsamic:develop-varcall_cnvkit",
+        DockerContainers.COVERAGE_QC: "docker://clinicalgenomics/balsamic:develop-coverage_qc",
+        DockerContainers.DELLY: "docker://clinicalgenomics/balsamic:develop-delly",
+        DockerContainers.CADD: "docker://clinicalgenomics/balsamic:develop-cadd",
+        DockerContainers.HTSLIB: "docker://clinicalgenomics/balsamic:develop-htslib",
+        DockerContainers.PURECN: "docker://clinicalgenomics/balsamic:develop-purecn",
+        DockerContainers.GATK: "docker://clinicalgenomics/balsamic:develop-gatk",
     }
 
 
@@ -2331,7 +2331,7 @@ def fixture_snakemake_executable_data(
 ) -> Dict[str, Any]:
     """Return snakemake executable model data."""
     return {
-        "account": ClusterAccount.DEVELOPMENT.value,
+        "account": ClusterAccount.DEVELOPMENT,
         "case_id": case_id_tumor_only,
         "cluster_config_path": reference_file,
         "config_path": reference_file,
@@ -2371,7 +2371,7 @@ def fixture_snakemake_executable_validated_data(
 ) -> Dict[str, Any]:
     """Return snakemake model expected data."""
     return {
-        "account": ClusterAccount.DEVELOPMENT.value,
+        "account": ClusterAccount.DEVELOPMENT,
         "benchmark": False,
         "case_id": case_id_tumor_only,
         "cluster_config_path": reference_file,

--- a/tests/models/test_snakemake_models.py
+++ b/tests/models/test_snakemake_models.py
@@ -250,8 +250,8 @@ def test_get_snakemake_command(
         f"--use-singularity --singularity-args '--cleanenv --bind {session_tmp_path.as_posix()}:/' --quiet "
         f"--immediate-submit -j {MAX_JOBS} --jobname BALSAMIC.{case_id_tumor_only}.{{rulename}}.{{jobid}}.sh "
         f"--cluster-config {reference_file.as_posix()} --cluster '{sys.executable} {SCHEDULER_PATH} "
-        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM.value} "
-        f"--account {ClusterAccount.DEVELOPMENT.value} --qos {QOS.HIGH.value} --log-dir {session_tmp_path} "
+        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM} "
+        f"--account {ClusterAccount.DEVELOPMENT} --qos {QOS.HIGH} --log-dir {session_tmp_path} "
         f"--script-dir {session_tmp_path} --result-dir {session_tmp_path} --mail-user {mail_user_option} "
         f"{{dependencies}} ' --config disable_variant_caller=tnscope,vardict --cores 36"
     )
@@ -278,8 +278,8 @@ def test_get_snakemake_cluster_options(
         snakemake_cluster_options
         == f"--immediate-submit -j {MAX_JOBS} --jobname BALSAMIC.{case_id_tumor_only}.{{rulename}}.{{jobid}}.sh "
         f"--cluster-config {reference_file.as_posix()} --cluster '{sys.executable} {SCHEDULER_PATH.as_posix()} "
-        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM.value} "
-        f"--account {ClusterAccount.DEVELOPMENT.value} --qos {QOS.HIGH.value} --log-dir {session_tmp_path} "
+        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM} "
+        f"--account {ClusterAccount.DEVELOPMENT} --qos {QOS.HIGH} --log-dir {session_tmp_path} "
         f"--script-dir {session_tmp_path} --result-dir {session_tmp_path} --mail-user {mail_user_option} "
         "{dependencies} '"
     )
@@ -303,8 +303,8 @@ def test_get_cluster_submit_command(
     # THEN the expected format should be returned
     assert snakemake_cluster_submit_command == (
         f"'{sys.executable} {SCHEDULER_PATH.as_posix()} "
-        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM.value} "
-        f"--account {ClusterAccount.DEVELOPMENT.value} --qos {QOS.HIGH.value} --log-dir {session_tmp_path} "
+        f"--sample-config {reference_file.as_posix()} --profile {ClusterProfile.SLURM} "
+        f"--account {ClusterAccount.DEVELOPMENT} --qos {QOS.HIGH} --log-dir {session_tmp_path} "
         f"--script-dir {session_tmp_path} --result-dir {session_tmp_path} --mail-user {mail_user_option} "
         "{dependencies} '"
     )


### PR DESCRIPTION
### This PR:

After upgrading to Python 3.11, we can now use `StrEnum` directly from the `enum` module. There's no longer a need to access` .value`, as we can work with these constants directly.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
