### PR TITLE
fix: make cadd snv optional

### DIFF
--- a/BALSAMIC/workflows/balsamic.smk
+++ b/BALSAMIC/workflows/balsamic.smk
@@ -113,15 +113,16 @@ research_annotations.append( {
 }
 )
 
-research_annotations.append( {
-    'annotation': [{
-    'file': Path(config["reference"]["cadd_snv"]).as_posix(),
-    'names': ["CADD"],
-    'ops': ["mean"],
-    'columns': [6]
-    }]
-}
-)
+if "cadd_snv" in config["reference"]:
+    research_annotations.append( {
+        'annotation': [{
+        'file': Path(config["reference"]["cadd_snv"]).as_posix(),
+        'names': ["CADD"],
+        'ops': ["mean"],
+        'columns': [6]
+        }]
+    }
+    )
 
 
 if "swegen_snv_frequency" in config["reference"]:


### PR DESCRIPTION
### This PR:

WIP. Missing issue at the moment.

Created this branch to make cadd_snv optional as the balsamic cache for hg38 did not have this file which prevented starting cases on hg38. But maybe I just have an incomplete cache...


Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
