### PR TITLE
refactor: Update gens tags

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
@@ -102,7 +102,7 @@ rule finalize_gens_outputfiles:
     params:
         sample_id="{sample}",
         gens_input="{gens_input}",
-        housekeeper_id= {"id": "{sample}", "tags": "clinical"}
+        housekeeper_id= {"id": "{sample}", "tags": "cnv"}
     benchmark:
         Path(benchmark_dir, "finalize_gens_outputfiles_{sample}_{gens_input}.tsv").as_posix()
     singularity:

--- a/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
@@ -98,11 +98,11 @@ rule finalize_gens_outputfiles:
     input:
         gens_input = cnv_dir + "{sample}.{gens_input}.bed"
     output:
-        gens_input_bgz = cnv_dir + "{sample}.{gens_input}.bed.gz",
+        gens_bed = cnv_dir + "{sample}.{gens_input}.bed.gz",
     params:
         sample_id="{sample}",
         gens_input="{gens_input}",
-        housekeeper_id= {"id": "{sample}", "tags": "gens"}
+        housekeeper_id= {"id": "{sample}", "tags": "clinical"}
     benchmark:
         Path(benchmark_dir, "finalize_gens_outputfiles_{sample}_{gens_input}.tsv").as_posix()
     singularity:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,7 @@ Changed:
 * Migrate analysis models to pydantic v2 https://github.com/Clinical-Genomics/BALSAMIC/pull/1306
 * Split analysis model into config and params models https://github.com/Clinical-Genomics/BALSAMIC/pull/1306
 * Renamed name in sample column of final clincial vcfs https://github.com/Clinical-Genomics/BALSAMIC/pull/1310
+* Update Gens HK tags https://github.com/Clinical-Genomics/BALSAMIC/pull/1319
 
 Fixed:
 ^^^^^^


### PR DESCRIPTION
### This PR:

With the current implementation, `balsamic report deliver` will generate redundant tags for HK: `gens-gens-input-bgz`. Changing it to `cnv-gens-bed`.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
