### PR TITLE
fix: gens_preprocessing rule missing python directive

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/gens_preprocessing.rule
@@ -90,8 +90,8 @@ rule gens_preprocessing:
         "Formatting output for GENS for sample: {params.sample}."
     shell:
         """
-{params.gens_preprocessing} -s {params.sequencing_type} -o {output.gens_baf_bed} calculate-bafs --vcf-file-path {input.gnomad_af5_vcf}
-{params.gens_preprocessing} -s {params.sequencing_type} -o {output.gens_cov_bed} create-coverage-regions --normalised-coverage-path {input.denoised_cr}
+python {params.gens_preprocessing} -s {params.sequencing_type} -o {output.gens_baf_bed} calculate-bafs --vcf-file-path {input.gnomad_af5_vcf}
+python {params.gens_preprocessing} -s {params.sequencing_type} -o {output.gens_cov_bed} create-coverage-regions --normalised-coverage-path {input.denoised_cr}
         """
 
 rule finalize_gens_outputfiles:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,7 @@ Fixed:
 * CNVpytor container, fixing numpy version https://github.com/Clinical-Genomics/BALSAMIC/pull/1273
 * QC workflow store https://github.com/Clinical-Genomics/BALSAMIC/pull/1295
 * MultiQC rule missing input files https://github.com/Clinical-Genomics/BALSAMIC/pull/1321
+* `gens_preprocessing` rule missing python directive https://github.com/Clinical-Genomics/BALSAMIC/pull/1322
 
 Removed:
 ^^^^^^^^


### PR DESCRIPTION
### This PR:

Fixes:
```
/bin/bash: line 1: /home/proj/stage/bin/miniconda3/envs/S_balsamic/lib/python3.11/site-packages/BALSAMIC/assets/scripts/preprocess_gens.py: Permission denied
```
### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
