### PR TITLE
fix: CADD annotations container path & (some) code smells

### DIFF
--- a/BALSAMIC/constants/constants.py
+++ b/BALSAMIC/constants/constants.py
@@ -26,6 +26,7 @@ class FileType(StrEnum):
     DICT: str = "dict"
     FAI: str = "fai"
     FASTA: str = "fasta"
+    FASTQ: str = "fastq"
     FLAT: str = "flat"
     GFF: str = "gff"
     GTF: str = "gtf"

--- a/BALSAMIC/constants/paths.py
+++ b/BALSAMIC/constants/paths.py
@@ -20,6 +20,9 @@ SENTIEON_TNSCOPE_DIR: Path = Path(
     SENTIEON_MODELS_DIR, "SentieonTNscopeModel_GiAB_HighAF_LowFP-201711.05.model"
 )
 
+# Singularity container hardcoded paths
+CADD_ANNOTATIONS_CONTAINER_DIR = Path("/opt/conda/share/CADD-scripts/data/annotations")
+
 # Pytest paths
 TEST_DATA_DIR: Path = Path("tests/test_data")
 FASTQ_TEST_INFO: Path = Path(TEST_DATA_DIR, "fastq_test_info.json")

--- a/BALSAMIC/utils/analysis.py
+++ b/BALSAMIC/utils/analysis.py
@@ -1,12 +1,11 @@
 """Utility functions for Balsamic analysis."""
 import os
 from pathlib import Path
-from typing import List, Any, Dict
+from typing import Any, Dict, List
 
 from BALSAMIC.constants.paths import (
     ASSETS_DIR,
     BALSAMIC_DIR,
-    CADD_ANNOTATIONS_DIR,
     CADD_ANNOTATIONS_CONTAINER_DIR,
 )
 from BALSAMIC.models.cache import CacheConfig

--- a/BALSAMIC/utils/analysis.py
+++ b/BALSAMIC/utils/analysis.py
@@ -3,7 +3,12 @@ import os
 from pathlib import Path
 from typing import List, Any, Dict
 
-from BALSAMIC.constants.paths import ASSETS_DIR, BALSAMIC_DIR
+from BALSAMIC.constants.paths import (
+    ASSETS_DIR,
+    BALSAMIC_DIR,
+    CADD_ANNOTATIONS_DIR,
+    CADD_ANNOTATIONS_CONTAINER_DIR,
+)
 from BALSAMIC.models.cache import CacheConfig
 from BALSAMIC.models.snakemake import SingularityBindPath
 from BALSAMIC.utils.cli import get_resolved_fastq_files_directory
@@ -45,12 +50,9 @@ def get_singularity_bind_paths(
         cadd_annotations_path: Path = Path(
             sample_config.get("reference").get("cadd_annotations")
         )
-        cadd_annotations_dest_path: Path = (
-            "/opt/conda/share/CADD-scripts/data/annotations"
-        )
         singularity_bind_paths.append(
             SingularityBindPath(
-                source=cadd_annotations_path, destination=cadd_annotations_dest_path
+                source=cadd_annotations_path, destination=CADD_ANNOTATIONS_CONTAINER_DIR
             )
         )
     return singularity_bind_paths

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,6 +83,7 @@ Fixed:
 * QC workflow store https://github.com/Clinical-Genomics/BALSAMIC/pull/1295
 * MultiQC rule missing input files https://github.com/Clinical-Genomics/BALSAMIC/pull/1321
 * `gens_preprocessing` rule missing python directive https://github.com/Clinical-Genomics/BALSAMIC/pull/1322
+* CADD annotations container path and code smells https://github.com/Clinical-Genomics/BALSAMIC/pull/1323
 
 Removed:
 ^^^^^^^^

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -316,7 +316,7 @@ def test_get_snakefile():
     ]
 
     # WHEN asking to see snakefile for paired
-    for reference_genome in ["hg19", "hg38", "canfam3"]:
+    for _reference_genome in ["hg19", "hg38", "canfam3"]:
         for analysis_type, analysis_workflow in workflow:
             snakefile = get_snakefile(analysis_type, analysis_workflow)
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -15,6 +15,7 @@ from _pytest.tmpdir import TempPathFactory
 from BALSAMIC.constants.analysis import BIOINFO_TOOL_ENV, SampleType, SequencingType
 from BALSAMIC.constants.cache import CacheVersion
 from BALSAMIC.constants.cluster import ClusterConfigType
+from BALSAMIC.constants.constants import FileType
 from BALSAMIC.constants.paths import CONTAINERS_DIR
 from BALSAMIC.models.config import ConfigModel, FastqInfoModel
 from BALSAMIC.utils.cli import (
@@ -279,8 +280,8 @@ def test_get_file_extension_get_any_ext():
 
 def test_get_file_extension_known_ext():
     # GIVEN a dummy file string with a known string
-    dummy_file = "hassan.fastq.gz"
-    actual_extension = "fastq.gz"
+    dummy_file = f"dummy.{FileType.FASTQ}.{FileType.GZ}"
+    actual_extension = f"{FileType.FASTQ}.{FileType.GZ}"
 
     # WHEN extracting the extension
     file_extension = get_file_extension(dummy_file)


### PR DESCRIPTION
### This PR:
String has been assigned instead of a Path for CADD annotations. There are also some code smells that we overlooked. 

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve