### PR TITLE
chore: fix non-unique labels in user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -44,7 +44,7 @@ body:
     required: false
 - type: checkboxes
   attributes:
-    label: Risk assessment
+    label: Risk assessment needed
     description: Is a risk assessment needed or not for this user story?
     options:
       - label: Needed


### PR DESCRIPTION
Fixes error introduced with last PR

### This PR:

Fixed: Now all labels are unique
