### PR TITLE
feat: Build and push release containers only when release PR is open or containers modified

### DIFF
--- a/.github/workflows/docker_build_publish_release.yml
+++ b/.github/workflows/docker_build_publish_release.yml
@@ -3,6 +3,13 @@ on:
   pull_request:
     branches:
       - "master"
+    types: [opened, reopened]
+  push:
+    branches:
+      - "release_v**"
+    paths:
+      - "BALSAMIC/containers/**"
+
 jobs:
   main:
     name: Build and publish


### PR DESCRIPTION
### This PR:

We should build and push release containers only when the release candidate PR is opened or when container fixes are pushed to it. With this approach, we wouldn't need to rebuild the cache with every fix to the release branch.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
