### PR TITLE
fix: remove extra samtools sort from wgs

### DIFF
--- a/BALSAMIC/snakemake_rules/align/postprocess_bam.rule
+++ b/BALSAMIC/snakemake_rules/align/postprocess_bam.rule
@@ -7,6 +7,28 @@
 # java.util.concurrent.CompletionException: java.lang.InternalError: a fault occurred in a recent unsafe memory access
 # It's however unclear how this resolves the issue.
 
+rule samtools_sort_index:
+    input:
+        bam = Path(bam_dir,"{sample_type}.{sample}.dedup.bam").as_posix(),
+    output:
+        bam = Path(bam_dir,"{sample_type}.{sample}.dedup_sorted.bam").as_posix(),
+    benchmark:
+        Path(benchmark_dir,"samtools_sort_index_{sample_type}_{sample}.tsv").as_posix()
+    singularity:
+        Path(singularity_image,config["bioinfo_tools"].get("samtools") + ".sif").as_posix()
+    params:
+        sample_id="{sample}"
+    threads:
+        get_threads(cluster_config,"samtools_sort_index")
+    message:
+        "Calculating alignment stats for sample: {params.sample_id}"
+    shell:
+        """
+samtools sort --threads {threads} -o {output.bam} {input.bam};
+samtools index -@ {threads} {output.bam};
+        """
+
+
 rule postprocess_bam:
     input:
         bam = Path(bam_dir,"{sample_type}.{sample}.dedup_sorted.bam").as_posix()

--- a/BALSAMIC/snakemake_rules/align/sentieon_alignment.rule
+++ b/BALSAMIC/snakemake_rules/align/sentieon_alignment.rule
@@ -89,33 +89,11 @@ shell_bam_files=$(echo {input.bam_files} | sed 's/ / -i /g') ;
 sed 's/^LIBRARY/\\n## METRICS CLASS\tpicard\.sam\.DuplicationMetrics\\nLIBRARY/' -i {output.metrics}
         """
 
-rule samtools_sort_index:
-    input:
-        bam = Path(bam_dir,"{sample_type}.{sample}.dedup.bam").as_posix(),
-    output:
-        bam = Path(bam_dir,"{sample_type}.{sample}.dedup_sorted.bam").as_posix(),
-    benchmark:
-        Path(benchmark_dir,"samtools_sort_index_{sample_type}_{sample}.tsv").as_posix()
-    singularity:
-        Path(singularity_image,config["bioinfo_tools"].get("samtools") + ".sif").as_posix()
-    params:
-        sample_id="{sample}"
-    threads:
-        get_threads(cluster_config,"samtools_qc")
-    message:
-        "Calculating alignment stats for sample: {params.sample_id}"
-    shell:
-        """
-samtools sort --threads {threads} -o {output.bam} {input.bam};
-samtools index -@ {threads} {output.bam};
-        """
-
-
 rule sentieon_realign:
     input:
         ref = config["reference"]["reference_genome"],
         mills = config["reference"]["mills_1kg"],
-        bam = Path(bam_dir, "{sample_type}.{sample}.dedup_sorted.bam").as_posix(),
+        bam = Path(bam_dir, "{sample_type}.{sample}.dedup.bam").as_posix(),
         indel_1kg = config["reference"]["known_indel_1kg"]
     output:
         bam = Path(bam_dir, "{sample_type}.{sample}.dedup.realign.bam").as_posix()


### PR DESCRIPTION
### This PR:

The extra added:
```
samtools sort --threads {threads} -o {output.bam} {input.bam};
samtools index -@ {threads} {output.bam};
```
Was only intended to fix the VarDict bug. It's unclear at the moment if this command added any benefit, and it may slow down a WGS analysis unnecessarily if we add it. 

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
