### PR TITLE
feat: change samtools stats to run per lane

### DIFF
--- a/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/multiqc.rule
@@ -4,9 +4,14 @@
 multiqc_input = [config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = tumor_sample)]
 
 multiqc_input.append(qc_dir + "tumor.{}.dedup.metrics".format(tumor_sample))
-multiqc_input.extend(expand(bam_dir + "{sample}.samtools.{stats}.txt",
-    sample=sample_names, stats=['flagstats', 'idxstats', 'stats']))
 
+
+multiqc_input.extend(expand(bam_dir + "{sample}_{fastq_pattern}.samtools.{stats}.txt",
+    sample=tumor_sample, fastq_pattern=config_model.get_fastq_patterns_by_sample(sample_names = tumor_sample), stats=['flagstats', 'idxstats', 'stats']))
+if config['analysis']['analysis_type'] == "paired":
+    multiqc_input.extend(expand(bam_dir + "{sample}_{fastq_pattern}.samtools.{stats}.txt",
+        sample=normal_sample,fastq_pattern=config_model.get_fastq_patterns_by_sample(sample_names=normal_sample),stats=[
+            'flagstats', 'idxstats', 'stats']))
 
 multiqc_input.extend(expand(bam_dir + "tumor.{sample}.cram", sample=tumor_sample))
 

--- a/BALSAMIC/snakemake_rules/quality_control/samtools_qc.rule
+++ b/BALSAMIC/snakemake_rules/quality_control/samtools_qc.rule
@@ -3,21 +3,22 @@
 
 rule samtools_qc:
     input:
-        bam = lambda wildcards: config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = wildcards.sample)
+        bam = Path(bam_dir, "{sample}_align_sort_{fastq_pattern}.bam").as_posix()
     output:
-        flagstats = Path(bam_dir, "{sample}.samtools.flagstats.txt").as_posix(),
-        idxstats = Path(bam_dir, "{sample}.samtools.idxstats.txt").as_posix(),
-        stats = Path(bam_dir, "{sample}.samtools.stats.txt").as_posix(),
+        flagstats = Path(bam_dir, "{sample}_{fastq_pattern}.samtools.flagstats.txt").as_posix(),
+        idxstats = Path(bam_dir, "{sample}_{fastq_pattern}.samtools.idxstats.txt").as_posix(),
+        stats = Path(bam_dir, "{sample}_{fastq_pattern}.samtools.stats.txt").as_posix(),
     benchmark:
-        Path(benchmark_dir,"samtools_qc_{sample}.tsv").as_posix()
+        Path(benchmark_dir,"samtools_qc_{sample}_{fastq_pattern}.tsv").as_posix()
     singularity:
         Path(singularity_image,config["bioinfo_tools"].get("samtools") + ".sif").as_posix()
     params:
-        sample_id = "{sample}"
+        sample_id = "{sample}",
+        fastq_pattern = "{fastq_pattern}"
     threads:
         get_threads(cluster_config, "samtools_qc")
     message:
-        "Calculating alignment stats for sample: {params.sample_id}"
+        "Calculating alignment stats for sample: {params.sample_id}, {params.fastq_pattern}"
     shell:
         """
 samtools flagstats --threads {threads} {input.bam} > {output.flagstats};


### PR DESCRIPTION
### This PR:

This change may be requested in order to get alignments stats per lane, which could be more informative for the QC project Arnold/Maven. 

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] Code review
- [ ] New code is executed and covered by tests, and test approve
