### PR TITLE
fix: use correct bcftools filter column for tumor in manta tumor only

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_sv_tumor_normal.rule
@@ -49,11 +49,11 @@ python {params.tmpdir}/runWorkflow.py -m {params.runmode} -j {threads};
 
 bgzip -l 9 {params.tmpdir}/results/variants/somaticSV_converted.vcf ;
 
-bcftools filter --threads {threads} --exclude 'SUM(FORMAT/PR[0:1]+FORMAT/SR[0:1]) < {params.low_pr_sr_count_value}' --soft-filter '{params.low_pr_sr_count_filter_name}' --mode '+' -o {output.final} -O z {params.tmpdir}/results/variants/somaticSV_converted.vcf.gz
+bcftools filter --threads {threads} --exclude 'SUM(FORMAT/PR[1:1]+FORMAT/SR[1:1]) < {params.low_pr_sr_count_value}' --soft-filter '{params.low_pr_sr_count_filter_name}' --mode '+' -o {output.final} -O z {params.tmpdir}/results/variants/somaticSV_converted.vcf.gz
 
 tabix -p vcf -f {output.final};
 
-echo -e \"{params.tumor}\\tTUMOR\\n{params.normal}\\tNORMAL\" > {output.namemap};
+echo -e \"{params.normal}\\tNORMAL\\n{params.tumor}\\tTUMOR\" > {output.namemap};
 
 rm -rf {params.tmpdir};
         """

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Removed:
 
 Fixed:
 ^^^^^^
-* ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/1395 
+* ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/1395
+* bcftools in manta_tumor_normal uses correct column for tumor read filtering https://github.com/Clinical-Genomics/BALSAMIC/pull/1400
 
 
 [13.0.1]


### PR DESCRIPTION
### This PR:

Correct bcftools filter in tumor / normal Manta rule to use the tumor column instead of the normal (bug). 

Issue was discovered during validation that the bcftools filter in the manta_tumor_normal rule was using the normal column for filtering (index 0) instead of the tumor (index 1). This is not an issue in the manta_tumor_only as the tumor there is index 0. By switching the sample in the tumor_normal manta rule to index 1 for the filter, it should work as expected.

Fixed: for any bug fixes.
- switched to use column 2 in the bcftools filter for the low_prsr filter in manta_tumor_normal rule

### Tests to verify that issue is correct:

Run bcftools on the raw somantic manta calls on tumor-normal cases and confirm that it applies filter on tumor column in sample: K (see https://docs.google.com/document/d/12x3ozQE62bk_yWNTBW_u8vZMqhpKFRMW3yizzM_mWZs/)

command:  `bcftools filter --threads 2 --exclude 'SUM(FORMAT/PR[1:1]+FORMAT/SR[1:1]) < 4' --soft-filter 'newfilter' --mode '+'`

Sets filter on 5 variants: PR:SR	66,0:82,0 (normal)	31,1:38,2 (tumor) 

original command sets filter on 504 variants: PR:SR	52,0:61,0 (normal)	63,5:81,2 (tumor)

- [x] Filter is working correctly!

### Review and tests: 
- [x] Tests pass
- [x] Code review
- [x] New code is executed and covered by tests, and test approve
