### PR TITLE
fix: PureCN rules

### DIFF
--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
@@ -187,7 +187,12 @@ rule purecn_call_CNV_research:
         """
 export PURECN='/opt/PureCN/PureCN.R'
 
+
 # Run PureCN to estimate tumor-purity and ploidy
+
+# Keep exit_status to bypass bash stict mode and continue even if purecn fails.
+exit_status="true"
+{{
 Rscript $PURECN \
 --parallel \
 --out {params.tmpdir} \
@@ -200,29 +205,32 @@ Rscript $PURECN \
 --fun-segmentation Hclust \
 --force --post-optimize \
 --seed 124;
+}} || exit_status="false"
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
-mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
-fi;
+if $exit_status; then
+    if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.pdf" ]];  then
-mv {params.tmpdir}/{params.sample_id}.pdf {params.purity_pdf};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}.pdf" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.pdf {params.purity_pdf};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_loh.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}_loh.csv {params.loh_regions};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}_loh.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_loh.csv {params.loh_regions};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_genes.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}_genes.csv {params.loh_genes};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}_genes.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_genes.csv {params.loh_genes};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.vcf.gz" ]];  then
-mv {params.tmpdir}/{params.sample_id}.vcf.gz {params.purecn_vcf};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}.vcf.gz" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.vcf.gz {params.purecn_vcf};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}.csv {output.purecn_purity};
+    if [[ -f "{params.tmpdir}/{params.sample_id}.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.csv {output.purecn_purity};
+    fi;
 else
 echo '"Sampleid","Purity","Ploidy","Sex","Contamination","Flagged","Failed","Curated","Comment"
 "tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,NA' > {output.purecn_purity}; 

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
@@ -233,7 +233,7 @@ if [ "$exit_status" = "true" ]; then
     fi;
 else
 echo '"Sampleid","Purity","Ploidy","Sex","Contamination","Flagged","Failed","Curated","Comment"
-"tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,NA' > {output.purecn_purity}; 
+"tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,"FAILED PURITY ESTIMATION"' > {output.purecn_purity}; 
 fi;
 
 rm -rf {params.tmpdir};

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_normal_tga.rule
@@ -207,7 +207,7 @@ Rscript $PURECN \
 --seed 124;
 }} || exit_status="false"
 
-if $exit_status; then
+if [ "$exit_status" = "true" ]; then
     if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
     mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
     fi;

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
@@ -126,6 +126,10 @@ rule purecn_call_CNV_research:
 export PURECN='/opt/PureCN/PureCN.R'
 
 # Run PureCN to estimate tumor-purity and ploidy
+
+# Keep exit_status to bypass bash stict mode and continue even if purecn fails.
+exit_status="true"
+{{
 Rscript $PURECN \
 --parallel \
 --out {params.tmpdir} \
@@ -138,29 +142,32 @@ Rscript $PURECN \
 --fun-segmentation Hclust \
 --force --post-optimize \
 --seed 124;
+}} || exit_status="false"
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
-mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
-fi;
+if $exit_status; then
+    if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.pdf" ]];  then
-mv {params.tmpdir}/{params.sample_id}.pdf {params.purity_pdf};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}.pdf" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.pdf {params.purity_pdf};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_loh.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}_loh.csv {params.loh_regions};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}_loh.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_loh.csv {params.loh_regions};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}_genes.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}_genes.csv {params.loh_genes};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}_genes.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}_genes.csv {params.loh_genes};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.vcf.gz" ]];  then
-mv {params.tmpdir}/{params.sample_id}.vcf.gz {params.purecn_vcf};
-fi;
+    if [[ -f "{params.tmpdir}/{params.sample_id}.vcf.gz" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.vcf.gz {params.purecn_vcf};
+    fi;
 
-if [[ -f "{params.tmpdir}/{params.sample_id}.csv" ]];  then
-mv {params.tmpdir}/{params.sample_id}.csv {output.purecn_purity};
+    if [[ -f "{params.tmpdir}/{params.sample_id}.csv" ]];  then
+    mv {params.tmpdir}/{params.sample_id}.csv {output.purecn_purity};
+    fi;
 else
 echo '"Sampleid","Purity","Ploidy","Sex","Contamination","Flagged","Failed","Curated","Comment"
 "tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,NA' > {output.purecn_purity};

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
@@ -170,7 +170,7 @@ if [ "$exit_status" = "true" ]; then
     fi;
 else
 echo '"Sampleid","Purity","Ploidy","Sex","Contamination","Flagged","Failed","Curated","Comment"
-"tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,NA' > {output.purecn_purity};
+"tumor.initial",0.02,2,"?",0,FALSE,FALSE,FALSE,"FAILED PURITY ESTIMATION"' > {output.purecn_purity};
 fi;
 
 rm -rf {params.tmpdir};

--- a/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/somatic_cnv_tumor_only_tga.rule
@@ -144,7 +144,7 @@ Rscript $PURECN \
 --seed 124;
 }} || exit_status="false"
 
-if $exit_status; then
+if [ "$exit_status" = "true" ]; then
     if [[ -f "{params.tmpdir}/{params.sample_id}_dnacopy.seg" ]];  then
     mv {params.tmpdir}/{params.sample_id}_dnacopy.seg {params.cnv_csv};
     fi;

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,11 @@
-[14.0.0]
+[[14.0.1]
+-------
+
+Fixed:
+^^^^^^
+* PureCN fail due to bash strict mode ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/
+
+14.0.0]
 -------
 
 Added:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
-[[14.0.1]
+[14.0.1]
 -------
 
 Fixed:
 ^^^^^^
-* PureCN fail due to bash strict mode ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/
+* PureCN fail due to bash strict mode ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/1406
 
 14.0.0]
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@
 
 Fixed:
 ^^^^^^
-* PureCN fail due to bash strict mode ASCAT-Ngs container https://github.com/Clinical-Genomics/BALSAMIC/pull/1406
+* PureCN fail due to bash strict mode https://github.com/Clinical-Genomics/BALSAMIC/pull/1406
 
 14.0.0]
 -------


### PR DESCRIPTION
## Description

PureCN rule fails due to bash strict mode when purity and ploidy can not be estimated. This causes the whole pipeline to terminate prematurely.




#### Fixed

- PureCN rules to bypass bash strict mode in both TO and TN workflows.



## Documentation

<!-- Link all added or updated documents. -->

- [x] N/A
- [ ] Updated Balsamic documentation to reflect the changes as needed for this PR.
    - [Document Name]

## Tests

<!-- Describe in detail how you tested your changes to help reviewers validate the code. -->
<!-- Include screenshots or visual representations of your changes. -->

### Feature Tests

<!-- Include tests relevant to the changes in this PR. -->

- [x] N/A
- [x] Test [Description]
    - [Screenshot]

### Pipeline Integrity Tests

<!-- Include tests to verify the integrity of the different Balsamic workflows. -->

- **Report deliver (generation of the `.hk` file)**
    - [x] N/A
    - [ ] Verified
- **TGA T/O Workflow**
    - [x] N/A
    - [ ] Verified
- **TGA T/N Workflow**
    - [x] N/A
    - [ ] Verified
- **UMI T/O Workflow**
    - [x] N/A
    - [ ] Verified
- **UMI T/N Workflow**
    - [x] N/A
    - [ ] Verified
- **WGS T/O Workflow**
    - [x] N/A
    - [ ] Verified
- **WGS T/N Workflow**
    - [x] N/A
    - [ ] Verified
- **QC Workflow**
    - [x] N/A
    - [ ] Verified
- **PON Workflow**
    - [x] N/A
    - [ ] Verified

## Clinical Genomics Stockholm

<details>
<summary></summary>

<!-- Do not reveal clinical data, and if applicable, place it within the internal Google Drive directory. -->

### Documentation

<!-- Link related issues or PRs for necessary changes. -->

- **Atlas documentation**
    - [x] N/A
    - [ ] Updated: [Link]
- **Web portal for Clinical Genomics**
    - [x] N/A
    - [ ] Updated: [Link]

### User Changes

<!-- Please provide justification if you select N/A and the changes affect the output or results. -->

- [x] N/A
- [ ] This PR affects the output files or results.
    - [ ] User feedback is considered unnecessary because [Justification].
    - [ ] Affected users have been included in the development process and given a chance to provide feedback.

### Infrastructure Changes

<!-- Link related issues or PRs for necessary changes. -->
<!-- Make sure that the linked PRs include relevant tests. -->

- **Stored files in Housekeeper**
    - [x] N/A
    - [ ] Updated: [Link]
- **CG (CLI and delivered/uploaded files)**
    - [x] N/A
    - [ ] Updated: [Link]
- **Servers (configuration files on Hasta)**
    - [x] N/A
    - [ ] Updated: [Link]
- **Scout interface**
    - [x] N/A
    - [ ] Updated: [Link]

</details>

## Checklist

> [!IMPORTANT]  
> Ensure that all checkboxes below are ticked before merging.

### For Developers

- **PR Description**
    - [x] Provided a comprehensive description of the PR.
    - [ ] Linked relevant user stories or issues to the PR.
- **Documentation**
    - [ ] Verified and updated documentation if necessary.
- **Tests**
    - [x] Described and tested the functionality addressed in the PR.
    - [x] Ensured integration of the new code with existing workflows.
    - [ ] Confirmed that meaningful unit tests were added for the changes introduced.
    - [x] Checked that the PR has successfully passed all relevant code smells and coverage checks.
- **Review**
    - [x] Addressed and resolved all the feedback provided during the code review process.
    - [ ] Obtained final approval from designated reviewers.

### For Reviewers

- **Code**
    - [x] Code implements the intended features or fixes the reported issue.
    - [x] Code follows the project's coding standards and style guide.
- **Documentation**
    - [x] Pipeline changes are well-documented in the CHANGELOG and relevant documentation.
- **Tests**
    - [x] The author provided a description of their manual testing, including consideration of edge cases and boundary
      conditions where applicable, with satisfactory results.
- **Review**
    - [x] Confirmed that the developer has addressed all the comments during the code review.

<!-- Add any other relevant information or specific checks necessary for your PR. -->
