### PR TITLE
fix: remove vardict parallelization per chrom

### DIFF
--- a/BALSAMIC/constants/cluster_analysis.json
+++ b/BALSAMIC/constants/cluster_analysis.json
@@ -27,6 +27,10 @@
 		"time": "01:00:00",
 		"n": 1
 	},
+	"pad_bedfile": {
+		"time": "01:00:00",
+		"n": 1
+	},
 	"cnvkit_create_coverage": {
 		"time": "6:00:00",
 		"n": 18
@@ -206,12 +210,12 @@
 	},
 	"vardict_tumor_normal": {
 		"time": "12:00:00",
-		"n": 1,
+		"n": 8,
 		"mem": 30000
 	},
 	"vardict_tumor_only": {
 		"time": "10:00:00",
-		"n": 1,
+		"n": 8,
 		"mem": 30000
 	},
 	"sentieon_TNscope": {

--- a/BALSAMIC/constants/cluster_analysis.json
+++ b/BALSAMIC/constants/cluster_analysis.json
@@ -206,11 +206,13 @@
 	},
 	"vardict_tumor_normal": {
 		"time": "12:00:00",
-		"n": 6
+		"n": 1,
+		"mem": 30000
 	},
 	"vardict_tumor_only": {
 		"time": "10:00:00",
-		"n": 6
+		"n": 1,
+		"mem": 30000
 	},
 	"sentieon_TNscope": {
 		"time": "24:00:00",

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
@@ -95,7 +95,7 @@ export PERL5LIB=;
 
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
+export VAR_DICT_OPTS='\"-Xms10G\" \"-Xmx25\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
 
 vardict-java -I 600 \
 -G {input.fa} \

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
@@ -95,7 +95,7 @@ export PERL5LIB=;
 
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\" \"-verbose:gc\" \"-XX:+PrintGCDetails\"'; 
+export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
 
 vardict-java -I 600 \
 -G {input.fa} \

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_t_varcall_tga.rule
@@ -71,11 +71,11 @@ rule vardict_tumor_only:
     input:
         fa = config["reference"]["reference_genome"],
         bamT = config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = tumor_sample),
-        bed = vcf_dir + "split_bed/{bedchrom}." + capture_kit,
+        bed = vcf_dir + "pad_bedfile/" + "100bp_padding_" + capture_kit
     output:
-        temp(vcf_dir + "vardict/split_vcf/{bedchrom}_vardict.vcf.gz")
+        vcf = vcf_dir + "vardict/vardict.vcf"
     benchmark:
-        Path(benchmark_dir, 'vardict_tumor_only_' + '{bedchrom}.tsv').as_posix()
+        Path(benchmark_dir,'vardict_tumor_only.tsv').as_posix()
     singularity:
         Path(singularity_image, config["bioinfo_tools"].get("vardict") + ".sif").as_posix()
     params:
@@ -95,7 +95,7 @@ export PERL5LIB=;
 
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
+export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\" \"-verbose:gc\" \"-XX:+PrintGCDetails\"'; 
 
 vardict-java -I 600 \
 -G {input.fa} \
@@ -106,16 +106,14 @@ vardict-java -I 600 \
 {params.col_info} {input.bed} \
 | teststrandbias.R \
 | var2vcf_valid.pl -P {params.max_pval} \
--m {params.max_mm} -E -f {params.af} -N {params.case_name} \
-| bgzip > {output};
+-m {params.max_mm} -E -f {params.af} -N {params.case_name} > {output.vcf};
 
-tabix -p vcf {output};
 rm -rf {params.tmpdir};
     """
 
 rule post_process_vardict:
     input:
-        vcf_sorted = vcf_dir + "vardict/merged_sorted.vardict.vcf"
+        vcf = vcf_dir + "vardict/vardict.sorted.vcf"
     output:
         vcf_vardict = vcf_dir + "vardict/SNV.somatic." + config["analysis"]["case_id"] + ".vardict.vcf.gz",
         namemap=vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".vardict.sample_name_map"
@@ -138,16 +136,16 @@ mkdir -p {params.tmpdir};
 export TMPDIR={params.tmpdir};
 
 python {params.edit_vcf_script} \
---input_vcf {input.vcf_sorted} \
---output_vcf {params.tmpdir}/vardict_merged_sorted.temp.vcf \
+--input_vcf {input.vcf} \
+--output_vcf {params.tmpdir}/vardict_edit.vcf \
 --variant_caller {params.variant_caller};
 
-bgzip {params.tmpdir}/vardict_merged_sorted.temp.vcf  ; 
-tabix -f -p vcf {params.tmpdir}/vardict_merged_sorted.temp.vcf.gz ;
+bgzip {params.tmpdir}/vardict_edit.vcf ; 
+tabix -f -p vcf {params.tmpdir}/vardict_edit.vcf.gz ;
 
 echo \"TUMOR\" > {params.tmpdir}/reheader ;
 
-bcftools reheader -s {params.tmpdir}/reheader {params.tmpdir}/vardict_merged_sorted.temp.vcf.gz -o {output.vcf_vardict} ;
+bcftools reheader -s {params.tmpdir}/reheader {params.tmpdir}/vardict_edit.vcf.gz -o {output.vcf_vardict} ;
 tabix -f -p vcf {output.vcf_vardict} ;
 
 echo -e \"tTUMOR\\tTUMOR\" > {output.namemap} ; 

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
@@ -74,11 +74,11 @@ rule vardict_tumor_normal:
         fa = config["reference"]["reference_genome"],
         bamN = config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = normal_sample),
         bamT = config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = tumor_sample),
-        bed = vcf_dir + "split_bed/{bedchrom}." + capture_kit,
+        bed = vcf_dir + "pad_bedfile/" + "100bp_padding_" + capture_kit
     output:
-        temp(vcf_dir + "vardict/split_vcf/{bedchrom}_vardict.vcf.gz")
+        vcf = vcf_dir + "vardict/vardict.vcf"
     benchmark:
-        Path(benchmark_dir,'vardict_tumor_normal_' + "{bedchrom}.tsv").as_posix()
+        Path(benchmark_dir,'vardict_tumor_normal.tsv').as_posix()
     singularity:
         Path(singularity_image, config["bioinfo_tools"].get("vardict") + ".sif").as_posix()
     params:
@@ -96,7 +96,7 @@ rule vardict_tumor_normal:
         """
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
+export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\" \"-verbose:gc\" \"-XX:+PrintGCDetails\"'; 
 
 vardict-java -I 600 -G {input.fa} -f {params.af} -N {params.case_name} \
 -b \"{input.bamT}|{input.bamN}\" \
@@ -104,16 +104,14 @@ vardict-java -I 600 -G {input.fa} -f {params.af} -N {params.case_name} \
 {params.col_info} {input.bed} \
 | testsomatic.R \
 | var2vcf_paired.pl -P {params.max_pval} \
--m {params.max_mm} -M -f {params.af} -N {params.case_name} \
-| bgzip > {output};
+-m {params.max_mm} -M -f {params.af} -N {params.case_name} > {output.vcf};
 
-tabix -p vcf {output};
 rm -rf {params.tmpdir};
     """
 
 rule post_process_vardict:
     input:
-        vcf_sorted = vcf_dir + "vardict/merged_sorted.vardict.vcf"
+        vcf = vcf_dir + "vardict/vardict.sorted.vcf"
     output:
         vcf_vardict = vcf_dir + "vardict/SNV.somatic." + config["analysis"]["case_id"] + ".vardict.vcf.gz",
         namemap = vcf_dir + "SNV.somatic." + config["analysis"]["case_id"] + ".vardict.sample_name_map"
@@ -136,17 +134,17 @@ mkdir -p {params.tmpdir};
 export TMPDIR={params.tmpdir};
 
 python {params.edit_vcf_script} \
---input_vcf {input.vcf_sorted} \
---output_vcf {params.tmpdir}/vardict_merged_sorted.temp.vcf \
+--input_vcf {input.vcf} \
+--output_vcf {params.tmpdir}/vardict_edit.vcf \
 --variant_caller {params.variant_caller};
 
-bgzip {params.tmpdir}/vardict_merged_sorted.temp.vcf  ; 
-tabix -f -p vcf {params.tmpdir}/vardict_merged_sorted.temp.vcf.gz ;
+bgzip {params.tmpdir}/vardict_edit.vcf \ ; 
+tabix -f -p vcf {params.tmpdir}/vardict_edit.vcf.gz ;
 
 echo \"TUMOR\" > {params.tmpdir}/reheader ;
 echo \"NORMAL\" >> {params.tmpdir}/reheader ;
 
-bcftools reheader -s {params.tmpdir}/reheader {params.tmpdir}/vardict_merged_sorted.temp.vcf.gz -o {output.vcf_vardict} ;
+bcftools reheader -s {params.tmpdir}/reheader {params.tmpdir}/vardict_edit.vcf.gz -o {output.vcf_vardict} ;
 tabix -f -p vcf {output.vcf_vardict} ;
 
 echo -e \"tTUMOR\\tTUMOR\\nNORMAL\\tNORMAL\" > {output.namemap} ; 

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
@@ -96,7 +96,7 @@ rule vardict_tumor_normal:
         """
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\" \"-verbose:gc\" \"-XX:+PrintGCDetails\"'; 
+export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
 
 vardict-java -I 600 -G {input.fa} -f {params.af} -N {params.case_name} \
 -b \"{input.bamT}|{input.bamN}\" \

--- a/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/snv_tn_varcall_tga.rule
@@ -96,7 +96,7 @@ rule vardict_tumor_normal:
         """
 export TMPDIR={params.tmpdir};
 export _JAVA_OPTIONS="-Djava.io.tmpdir={params.tmpdir} -Xss256k"; 
-export VAR_DICT_OPTS='\"-Xms5G\" \"-Xmx15G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
+export VAR_DICT_OPTS='\"-Xms10\" \"-Xmx25G\" \"-XX:+UseG1GC\" \"-XX:MaxHeapFreeRatio=50\"'; 
 
 vardict-java -I 600 -G {input.fa} -f {params.af} -N {params.case_name} \
 -b \"{input.bamT}|{input.bamN}\" \

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict_pre_and_postprocessing.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict_pre_and_postprocessing.rule
@@ -28,7 +28,7 @@ sed 's/^chr//g;/_/d' {input.chrom} | sort -k1,1 > {params.pad_bed_dir}hg19.chrom
 
 bedtools slop -b 100 -i {input.bed} -g {params.pad_bed_dir}hg19.chrom.sizes \
 | sort -k1,1 -k2,2n \
-| bedtools merge > {params.pad_bed_dir}100bp_padding_{params.origin_bed}; done;
+| bedtools merge > {params.pad_bed_dir}100bp_padding_{params.origin_bed} ;
 
 readlink -f {input.bam};
         """

--- a/BALSAMIC/snakemake_rules/variant_calling/vardict_pre_and_postprocessing.rule
+++ b/BALSAMIC/snakemake_rules/variant_calling/vardict_pre_and_postprocessing.rule
@@ -1,72 +1,43 @@
 
 
-rule bedtools_splitbed_by_chrom:
+rule bedtools_pad_bedfile:
     input:
         bed = config["panel"]["capture_kit"],
         chrom = config["reference"]["genome_chrom_size"],
         bam = config_model.get_final_bam_name(bam_dir = bam_dir, sample_name = tumor_sample)
     output:
-        bed = expand(vcf_dir + "split_bed/" + "{chrom}." + capture_kit, chrom=chromlist)
+        bed = vcf_dir + "pad_bedfile/" + "100bp_padding_" + capture_kit
     benchmark:
-        Path(benchmark_dir, 'bedtools_splitbed_by_chrom.tsv').as_posix()
+        Path(benchmark_dir, 'bedtools_pad_bedfile.tsv').as_posix()
     singularity:
         Path(singularity_image, config["bioinfo_tools"].get("bedtools") + ".sif").as_posix()
+    threads:
+        get_threads(cluster_config, "pad_bedfile")
     params:
         tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
-        split_bed_dir = vcf_dir + "split_bed/",
+        pad_bed_dir = vcf_dir + "pad_bedfile/",
         origin_bed = capture_kit,
     message:
-        ("Splitting the panel bed per chromosome, flanking regions by 100bp and merging into single VCF using bedtools")
+        "Padding 100bp to target capture bedfile."
     shell:
         """
 mkdir -p {params.tmpdir};
 export TMPDIR={params.tmpdir};
 
-chromlist=`cut -f 1 {input.bed} | sort -u`;
-sed 's/^chr//g;/_/d' {input.chrom} | sort -k1,1 > {params.split_bed_dir}hg19.chrom.sizes;
+sed 's/^chr//g;/_/d' {input.chrom} | sort -k1,1 > {params.pad_bed_dir}hg19.chrom.sizes;
 
-for c in $chromlist; do \
-awk -v C=$c '$1==C' {input.bed} \
-| bedtools slop -b 100 -i - -g {params.split_bed_dir}hg19.chrom.sizes \
+bedtools slop -b 100 -i {input.bed} -g {params.pad_bed_dir}hg19.chrom.sizes \
 | sort -k1,1 -k2,2n \
-| bedtools merge > {params.split_bed_dir}$c.{params.origin_bed}; done;
+| bedtools merge > {params.pad_bed_dir}100bp_padding_{params.origin_bed}; done;
 
-unset chromlist; 
 readlink -f {input.bam};
         """
 
-rule vardict_merge:
-    input:
-        expand(vcf_dir + "vardict/split_vcf/{chrom}_vardict.vcf.gz", chrom=chromlist)
-    output:
-        vcf_vardict = vcf_dir + "vardict/merged.vardict.vcf"
-    params:
-        tmpdir = tempfile.mkdtemp(prefix=tmp_dir),
-        sort_vcf = get_script_path("sort_vcf.awk"),
-        case_name = config["analysis"]["case_id"],
-    benchmark:
-        Path(benchmark_dir,'vardict_merge_' + config["analysis"]["case_id"] + ".tsv").as_posix()
-    singularity:
-        Path(singularity_image, config["bioinfo_tools"].get("bcftools") + ".sif").as_posix()
-    threads:
-        get_threads(cluster_config,"vardict_merge")
-    message:
-        ("Merging multiple VCFs from vardict into single VCF using bcftools for {params.case_name}")
-    shell:
-        """
-mkdir -p {params.tmpdir};
-export TMPDIR={params.tmpdir};
-
-bcftools concat {input} > {output.vcf_vardict} ;
-
-rm -rf {params.tmpdir} ;
-    """
-
 rule vardict_sort:
     input:
-        vcf = vcf_dir + "vardict/merged.vardict.vcf"
+        vcf = vcf_dir + "vardict/vardict.vcf"
     output:
-        vcf_sorted = vcf_dir + "vardict/merged_sorted.vardict.vcf"
+        vcf_sorted = vcf_dir + "vardict/vardict.sorted.vcf"
     params:
         tmpdir=tempfile.mkdtemp(prefix=tmp_dir),
         sort_vcf=get_script_path("sort_vcf.awk"),
@@ -76,7 +47,7 @@ rule vardict_sort:
     threads:
         get_threads(cluster_config,"vardict_sort")
     message:
-        ("Sorting merged vardict files with awk {params.case_name}")
+        ("Sorting VarDict VCF with awk {params.case_name}")
     shell:
         """
 mkdir -p {params.tmpdir};

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed:
 * Change VarDict memory usage to fix crashes in production https://github.com/Clinical-Genomics/BALSAMIC/pull/1537
 * Updated cluster resources for tnscope WGS TN https://github.com/Clinical-Genomics/BALSAMIC/pull/1535
 * Disable SV calling in TNscope https://github.com/Clinical-Genomics/BALSAMIC/pull/1541
+* Remove VarDict parallelization per chromosome https://github.com/Clinical-Genomics/BALSAMIC/pull/1544
 
 Removed:
 ^^^^^^^^


### PR DESCRIPTION
## Description

<!-- Provide a brief overview of your PR and link any relevant user stories or issues. -->

VarDict is failing on a frequency of about 1/120 jobs. Each case we're submitting has 24 jobs for VarDict as we're splitting them up per chromosome. As we have not been able to solve the VarDict issue I would argue that a reasonable way of reducing the effect of it could be to remove the amount of VarDict jobs per case, by removing the parallelisation per chromosome. 

On an average panel case each VarDict chromosome job has finished in under a minute, even when running only on 1 thread. 

#### Removed

- remove parallelization per chromosome for VarDict

## Documentation

<!-- Link all added or updated documents. -->

- [x] N/A
- [ ] Updated Balsamic documentation to reflect the changes as needed for this PR.
    - [Document Name]

## Tests

<!-- Describe in detail how you tested your changes to help reviewers validate the code. -->
<!-- Include screenshots or visual representations of your changes. -->

### Feature Tests

<!-- Include tests relevant to the changes in this PR. -->

- [x] Running VarDict on single bam produces same output has been verified
- [x] Test running VarDict for entire bamfile works and is not slow

See table below for the same case, running VarDict in parallel per chromosome vs running the entire bamfile at once **(last row)**.
The total amount of seconds run on the cluster for the parallel jobs were: 1231 where as it took 350 seconds to run VarDict once.

| **JOB**                     | **s**      | **h:m:s** | **max_rss** | **max_vms** | **max_uss** | **max_pss** | **io_in** | **io_out** | **mean_load** | **cpu_time** |
|-----------------------------|------------|-----------|-------------|-------------|-------------|-------------|-----------|------------|---------------|--------------|
| vardict_tumor_only_10.tsv   | 33.1588    | 0:00:33   | 3306.12     | 19905.98    | 3302.75     | 3304.16     | 28.67     | 0.04       | 108.88        | 36.48        |
| vardict_tumor_only_11.tsv   | 72.2374    | 0:01:12   | 3300.12     | 19908.11    | 3297.62     | 3298.64     | 28.67     | 0.05       | 99.26         | 71.87        |
| vardict_tumor_only_12.tsv   | 135.4927   | 0:02:15   | 3307.68     | 19908.11    | 3305.17     | 3306.19     | 28.67     | 0.11       | 96.28         | 130.88       |
| vardict_tumor_only_13.tsv   | 20.8985    | 0:00:20   | 3277.09     | 19905.97    | 3273.71     | 3275.22     | 28.64     | 0.03       | 136.26        | 28.54        |
| vardict_tumor_only_14.tsv   | 34.4785    | 0:00:34   | 3303.86     | 19908.36    | 3300.21     | 3301.71     | 28.67     | 0.04       | 102.39        | 35.74        |
| vardict_tumor_only_15.tsv   | 34.8706    | 0:00:34   | 3287.72     | 19905.98    | 3283.99     | 3285.77     | 28.63     | 0.03       | 88.11         | 31.93        |
| vardict_tumor_only_16.tsv   | 73.5754    | 0:01:13   | 3315.5      | 19905.98    | 3313.18     | 3314.2      | 28.63     | 0.05       | 94.8          | 70.11        |
| vardict_tumor_only_17.tsv   | 67.1678    | 0:01:07   | 3284.32     | 19907.97    | 3280.9      | 3282.41     | 28.68     | 0.09       | 96.94         | 65.23        |
| vardict_tumor_only_18.tsv   | 14.21      | 0:00:14   | 3310.28     | 19905.98    | 3307.83     | 3308.85     | 28.81     | 0.03       | 203.6         | 30.14        |
| vardict_tumor_only_19.tsv   | 49.6443    | 0:00:49   | 3284.03     | 19906.11    | 3282.06     | 3283.08     | 28.67     | 0.06       | 141.79        | 70.7         |
| vardict_tumor_only_1.tsv    | 76.8567    | 0:01:16   | 3301.18     | 19906.11    | 3298.84     | 3299.84     | 28.87     | 0.11       | 79.98         | 61.6         |
| vardict_tumor_only_20.tsv   | 30.8993    | 0:00:30   | 3276.98     | 19905.98    | 3275        | 3276.02     | 28.67     | 0.04       | 97.49         | 31           |
| vardict_tumor_only_21.tsv   | 8.8728     | 0:00:08   | 3288.43     | 19905.98    | 3285.89     | 3286.93     | 28.85     | 0.04       | 226.02        | 21.19        |
| vardict_tumor_only_22.tsv   | 67.9363    | 0:01:07   | 3295.69     | 19905.97    | 3293.11     | 3294.12     | 28.68     | 0.07       | 95.34         | 66.13        |
| vardict_tumor_only_2.tsv    | 52.3472    | 0:00:52   | 3298.64     | 19907.92    | 3296.21     | 3297.23     | 28.67     | 0.07       | 135.51        | 72.18        |
| vardict_tumor_only_3.tsv    | 53.7103    | 0:00:53   | 3299        | 19906.11    | 3296.36     | 3297.51     | 28.68     | 0.07       | 118.31        | 63.65        |
| vardict_tumor_only_4.tsv    | 60.6765    | 0:01:00   | 3293.36     | 19905.97    | 3290.3      | 3291.52     | 28.68     | 0.07       | 98.33         | 59.83        |
| vardict_tumor_only_5.tsv    | 49.0207    | 0:00:49   | 3311.58     | 19908.11    | 3309.18     | 3310.2      | 28.63     | 0.08       | 141.45        | 70.67        |
| vardict_tumor_only_6.tsv    | 45.1804    | 0:00:45   | 3293.89     | 19905.97    | 3290.8      | 3292.01     | 28.68     | 0.03       | 55.49         | 25.24        |
| vardict_tumor_only_7.tsv    | 105.2191   | 0:01:45   | 3321.3      | 19908.91    | 3318.88     | 3319.89     | 28.67     | 0.08       | 104.13        | 109.94       |
| vardict_tumor_only_8.tsv    | 21.9548    | 0:00:21   | 3287.87     | 19907.67    | 3285.65     | 3286.67     | 28.67     | 0.04       | 143.64        | 32.65        |
| vardict_tumor_only_9.tsv    | 57.0019    | 0:00:57   | 3314.57     | 19905.98    | 3311.04     | 3312.6      | 28.67     | 0.06       | 125.5         | 72.74        |
| vardict_tumor_only_X.tsv    | 58.9875    | 0:00:58   | 3305.21     | 19908.62    | 3301.62     | 3303.23     | 28.67     | 0.06       | 123.26        | 74.21        |
| vardict_tumor_only_Y.tsv    | 6.865      | 0:00:06   | 779.31      | 19908.06    | 769.78      | 770.8       | 28.63     | 0.03       | 144.41        | 10.18        |
| **vardict_tumor_only.tsv**      | 349.723    | 0:05:49   | 3456.69     | 21043.38    | 3437.65     | 3441.29     | 28.71     | 0.3        | 351.29        | 1228.78      |

Doing the same check for TN case selectbengal shows the same pattern. Total amount of seconds for all jobs together was 10922 seconds, whereas for the single job it was 6888 seconds. 

| jobs                | s         | h:m:s   | max_rss | max_vms  | max_uss | max_pss | io_in | io_out | mean_load | cpu_time |
|-----------------------------|-----------|---------|---------|----------|---------|---------|-------|--------|-----------|----------|
| vardict_tumor_normal_10.tsv |  324.9657 | 0:05:24 | 3422.43 | 19912.09 | 3417.93 | 3419.62 | 28.67 |   0.21 |    112.33 |   365.39 |
| vardict_tumor_normal_11.tsv |  1048.855 | 0:17:28 | 3480.42 | 19977.52 | 3477.91 | 3478.93 | 28.67 |   0.65 |    105.28 |  1104.37 |
| vardict_tumor_normal_12.tsv | 1814.7347 | 0:30:14 | 3583.98 | 19913.39 | 3581.46 | 3582.48 | 28.67 |      1 |    101.98 |  1850.46 |
| vardict_tumor_normal_13.tsv |  829.2982 | 0:13:49 | 3416.23 | 19912.36 | 3413.64 | 3414.66 | 28.87 |   0.47 |    102.45 |   849.91 |
| vardict_tumor_normal_14.tsv |  130.0354 | 0:02:10 | 3310.93 | 19911.71 | 3306.08 | 3307.99 | 28.67 |   0.11 |    107.48 |   139.96 |
| vardict_tumor_normal_15.tsv |  129.3562 | 0:02:09 | 3318.99 |  19911.7 |  3313.8 | 3315.77 | 28.67 |   0.11 |    104.95 |   135.94 |
| vardict_tumor_normal_16.tsv |  284.1518 | 0:04:44 | 3419.52 | 19976.48 | 3417.12 | 3418.14 | 28.67 |   0.18 |     105.4 |   299.63 |
| vardict_tumor_normal_17.tsv |  1120.884 | 0:18:40 | 3397.47 | 19978.18 | 3394.84 | 3395.86 | 28.67 |   0.63 |    103.35 |  1158.63 |
| vardict_tumor_normal_18.tsv |   68.0369 | 0:01:08 | 3314.26 | 19911.06 | 3309.52 | 3311.67 | 28.67 |   0.07 |     99.18 |    67.64 |
| vardict_tumor_normal_19.tsv |  416.2561 | 0:06:56 | 3384.02 | 19976.87 | 3380.43 | 3381.48 | 28.67 |   0.27 |    109.33 |   456.35 |
| vardict_tumor_normal_1.tsv  |   686.667 | 0:11:26 | 3408.69 | 19914.42 |  3406.2 | 3407.29 | 28.87 |   0.39 |    101.97 |   700.56 |
| vardict_tumor_normal_20.tsv |  144.4134 | 0:02:24 | 3293.02 |  19911.7 | 3288.33 | 3290.27 | 28.68 |   0.11 |    111.13 |   160.86 |
| vardict_tumor_normal_21.tsv |  724.0187 | 0:12:04 |  3378.7 | 19911.31 | 3376.24 | 3377.25 | 28.68 |   0.42 |    100.04 |   724.47 |
| vardict_tumor_normal_22.tsv |  367.9359 | 0:06:07 | 3337.49 | 19911.95 | 3333.96 | 3335.38 | 28.68 |   0.23 |     101.9 |   375.18 |
| vardict_tumor_normal_2.tsv  |   576.854 | 0:09:36 | 3370.14 | 19912.99 | 3367.78 |  3368.8 | 28.68 |   0.33 |    103.78 |   598.96 |
| vardict_tumor_normal_3.tsv  |  304.8291 | 0:05:04 | 3362.08 | 19912.61 | 3358.71 | 3359.89 | 28.67 |    0.2 |    110.31 |   336.61 |
| vardict_tumor_normal_4.tsv  |  352.4116 | 0:05:52 | 3359.11 |  19912.6 | 3355.44 | 3356.86 | 28.87 |   0.21 |    101.26 |   357.12 |
| vardict_tumor_normal_5.tsv  |  422.1352 | 0:07:02 | 3400.34 | 19976.75 | 3396.54 | 3397.82 | 28.67 |   0.24 |    109.86 |   464.13 |
| vardict_tumor_normal_6.tsv  |  441.8272 | 0:07:21 | 3419.56 | 19912.75 |  3416.4 | 3417.43 | 28.85 |   0.29 |    103.17 |   456.14 |
| vardict_tumor_normal_8.tsv  |  227.9968 | 0:03:47 | 3332.48 | 19911.96 |  3328.4 | 3330.09 | 28.87 |   0.19 |    103.25 |   235.58 |
| vardict_tumor_normal_9.tsv  |  347.8981 | 0:05:47 | 3314.63 | 19913.11 | 3310.03 | 3311.97 | 28.87 |   0.22 |    103.49 |   360.34 |
| vardict_tumor_normal_X.tsv  |  156.1031 | 0:02:36 | 3345.82 | 19911.57 | 3339.94 | 3342.62 | 28.68 |   0.14 |    100.87 |   157.61 |
| vardict_tumor_normal_Y.tsv  |    2.9038 | 0:00:02 |  206.38 | 19909.06 |  200.26 |  202.01 | 28.63 |   0.03 |    109.66 |     3.54 |
| **vardict_tumor_normal.tsv**    | 6888.0774 | 1:54:48 | 5533.16 | 21164.66 | 5489.63 | 5496.66 | 28.76 |   4.34 |    198.42 | 13667.73 |


### Pipeline Integrity Tests

<!-- Include tests to verify the integrity of the different Balsamic workflows. -->

- **Report deliver (generation of the `.hk` file)**
    - [x] N/A
    - [ ] Verified
- **TGA T/O Workflow**
    - [ ] N/A
    - [x] Verified
- **TGA T/N Workflow**
    - [ ] N/A
    - [x] Verified
- **UMI T/O Workflow**
    - [ ] N/A
    - [x] Verified
- **UMI T/N Workflow**
    - [ ] N/A
    - [x] Verified
- **WGS T/O Workflow**
    - [x] N/A
    - [ ] Verified
- **WGS T/N Workflow**
    - [x] N/A
    - [ ] Verified
- **QC Workflow**
    - [x] N/A
    - [ ] Verified
- **PON Workflow**
    - [x] N/A
    - [ ] Verified

## Clinical Genomics Stockholm

<!-- Do not reveal clinical data, and if applicable, place it within the internal Google Drive directory. -->

### Documentation

<!-- Link related issues or PRs for necessary changes. -->

- **Atlas documentation**
    - [x] N/A
    - [ ] Updated: [Link]
- **Web portal for Clinical Genomics**
    - [x] N/A
    - [ ] Updated: [Link]

### Panel of Normal specific criteria

<!-- If the PR includes a new PoN adhere to the criteria below. -->

- [ ] The PR includes the addition of a new Panel of Normals
- [ ] The samples have been verified to adhere to the sample selection criteria on [Atlas PoN creation instructions for Balsamic](https://atlas.scilifelab.se/infrastructure/BALSAMIC/balsamic_pon/#procedure)

### User Changes

<!-- Please provide justification if you select N/A and the changes affect the output or results. -->

- [x] N/A
- [ ] This PR affects the output files or results.
    - [ ] User feedback is considered unnecessary because [Justification].
    - [ ] Affected users have been included in the development process and given a chance to provide feedback.

### Infrastructure Changes

<!-- Link related issues or PRs for necessary changes. -->
<!-- Make sure that the linked PRs include relevant tests. -->

- **Stored files in Housekeeper**
    - [x] N/A
    - [ ] Updated: [Link]
- **CG (CLI and delivered/uploaded files)**
    - [x] N/A
    - [ ] Updated: [Link]
- **Servers (configuration files on Hasta)**
    - [x] N/A
    - [ ] Updated: [Link]
- **Scout interface**
    - [x] N/A
    - [ ] Updated: [Link]

### Validation criteria

<!-- Create validation criteria for this PR or mark as unnecessary. -->

Validation criteria to be added to validation report PR: [LINK-TO-VALIDATION-REPORT-PR from the [validations repository](https://github.com/Clinical-Genomics/validations/)]

**Version specific criteria**

- Text here or N/A



> [!IMPORTANT]
> One of the below checkboxes for validation need to be checked 

- [ ] Added version specific validation criteria to validation report
- [ ] Changes validated in standard sections: [validation-section]
- [x] Validation criteria not necessary

## Checklist

> [!IMPORTANT]  
> Ensure that all checkboxes below are ticked before merging.

### For Developers

- **PR Description**
    - [x] Provided a comprehensive description of the PR.
    - [ ] Linked relevant user stories or issues to the PR.
- **Documentation**
    - [x] Verified and updated documentation if necessary.
- **Validation criteria**
    - [x] Completed the validation criteria section of the template.
- **Tests**
    - [x] Described and tested the functionality addressed in the PR.
    - [x] Ensured integration of the new code with existing workflows.
    - [x] Confirmed that meaningful unit tests were added for the changes introduced.
    - [x] Checked that the PR has successfully passed all relevant code smells and coverage checks.
- **Review**
    - [ ] Addressed and resolved all the feedback provided during the code review process.
    - [ ] Obtained final approval from designated reviewers.

### For Reviewers

- **Code**
    - [ ] Code implements the intended features or fixes the reported issue.
    - [ ] Code follows the project's coding standards and style guide.
- **Documentation**
    - [ ] Pipeline changes are well-documented in the CHANGELOG and relevant documentation.
- **Validation criteria**
    - [ ] The author has completed the validation criteria section of the template
- **Tests**
    - [ ] The author provided a description of their manual testing, including consideration of edge cases and boundary
      conditions where applicable, with satisfactory results.
- **Review**
    - [ ] Confirmed that the developer has addressed all the comments during the code review.

<!-- Add any other relevant information or specific checks necessary for your PR. -->
